### PR TITLE
feat: add SafeTensors parser and HuggingFace config parser

### DIFF
--- a/crates/forgellm-frontend/src/config.rs
+++ b/crates/forgellm-frontend/src/config.rs
@@ -1,0 +1,265 @@
+//! HuggingFace model config.json parser.
+//!
+//! Parses the `config.json` that accompanies SafeTensors model files
+//! to extract architecture type and hyperparameters.
+
+use serde::Deserialize;
+
+use crate::ir::{Architecture, DType, ModelConfig};
+
+/// Raw HuggingFace config.json structure.
+/// Fields are optional since different architectures use different keys.
+#[derive(Debug, Deserialize)]
+pub struct HFConfig {
+    /// Architecture identifiers
+    pub model_type: Option<String>,
+    pub architectures: Option<Vec<String>>,
+
+    /// Core dimensions
+    pub hidden_size: Option<usize>,
+    pub intermediate_size: Option<usize>,
+    pub num_hidden_layers: Option<usize>,
+    pub num_attention_heads: Option<usize>,
+    pub num_key_value_heads: Option<usize>,
+    pub head_dim: Option<usize>,
+    pub vocab_size: Option<usize>,
+    pub max_position_embeddings: Option<usize>,
+
+    /// Normalization
+    pub rms_norm_eps: Option<f64>,
+    pub layer_norm_eps: Option<f64>,
+    pub layer_norm_epsilon: Option<f64>,
+
+    /// RoPE
+    pub rope_theta: Option<f64>,
+
+    /// Data type
+    pub torch_dtype: Option<String>,
+}
+
+impl HFConfig {
+    /// Parse from JSON bytes.
+    pub fn from_json(json: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(json)
+    }
+
+    /// Detect the model architecture.
+    pub fn detect_architecture(&self) -> Option<Architecture> {
+        // Try model_type first
+        if let Some(ref model_type) = self.model_type {
+            match model_type.as_str() {
+                "llama" => return Some(Architecture::Llama),
+                "qwen2" => return Some(Architecture::Qwen2),
+                "mistral" => return Some(Architecture::Mistral),
+                "phi3" | "phi" => return Some(Architecture::Phi3),
+                "gemma" | "gemma2" => return Some(Architecture::Gemma),
+                "stablelm" | "stablelm_epoch" => return Some(Architecture::StableLM),
+                _ => {}
+            }
+        }
+
+        // Fall back to architectures list
+        if let Some(ref archs) = self.architectures {
+            for arch in archs {
+                if arch.contains("Llama") {
+                    return Some(Architecture::Llama);
+                }
+                if arch.contains("Qwen2") {
+                    return Some(Architecture::Qwen2);
+                }
+                if arch.contains("Mistral") {
+                    return Some(Architecture::Mistral);
+                }
+                if arch.contains("Phi3") || arch.contains("Phi") {
+                    return Some(Architecture::Phi3);
+                }
+                if arch.contains("Gemma") {
+                    return Some(Architecture::Gemma);
+                }
+                if arch.contains("StableLm") || arch.contains("StableLM") {
+                    return Some(Architecture::StableLM);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Convert to a ModelConfig for the IR.
+    pub fn to_model_config(&self) -> Option<ModelConfig> {
+        let architecture = self.detect_architecture()?;
+        let hidden_size = self.hidden_size?;
+        let num_attention_heads = self.num_attention_heads?;
+
+        let head_dim = self.head_dim.unwrap_or(hidden_size / num_attention_heads);
+
+        let num_kv_heads = self.num_key_value_heads.unwrap_or(num_attention_heads);
+
+        let norm_eps = self
+            .rms_norm_eps
+            .or(self.layer_norm_eps)
+            .or(self.layer_norm_epsilon)
+            .unwrap_or(1e-5);
+
+        let dtype = self
+            .torch_dtype
+            .as_deref()
+            .map(parse_torch_dtype)
+            .unwrap_or(DType::F16);
+
+        Some(ModelConfig {
+            architecture,
+            hidden_size,
+            intermediate_size: self.intermediate_size.unwrap_or(hidden_size * 4),
+            num_layers: self.num_hidden_layers?,
+            num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            vocab_size: self.vocab_size.unwrap_or(32000),
+            max_seq_len: self.max_position_embeddings.unwrap_or(2048),
+            rms_norm_eps: norm_eps as f32,
+            rope_theta: self.rope_theta.unwrap_or(10000.0) as f32,
+            dtype,
+        })
+    }
+}
+
+fn parse_torch_dtype(s: &str) -> DType {
+    match s {
+        "float32" | "fp32" => DType::F32,
+        "float16" | "fp16" => DType::F16,
+        "bfloat16" | "bf16" => DType::BF16,
+        _ => DType::F16,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_llama_config() {
+        let json = r#"{
+            "model_type": "llama",
+            "architectures": ["LlamaForCausalLM"],
+            "hidden_size": 2048,
+            "intermediate_size": 5632,
+            "num_hidden_layers": 16,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "vocab_size": 32000,
+            "max_position_embeddings": 2048,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "torch_dtype": "float16"
+        }"#;
+
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        assert_eq!(config.detect_architecture(), Some(Architecture::Llama));
+
+        let mc = config.to_model_config().unwrap();
+        assert_eq!(mc.hidden_size, 2048);
+        assert_eq!(mc.intermediate_size, 5632);
+        assert_eq!(mc.num_layers, 16);
+        assert_eq!(mc.num_attention_heads, 32);
+        assert_eq!(mc.num_kv_heads, 8);
+        assert_eq!(mc.head_dim, 64);
+        assert_eq!(mc.vocab_size, 32000);
+        assert_eq!(mc.dtype, DType::F16);
+    }
+
+    #[test]
+    fn parse_qwen2_config() {
+        let json = r#"{
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+            "hidden_size": 1536,
+            "intermediate_size": 8960,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 12,
+            "num_key_value_heads": 2,
+            "vocab_size": 151936,
+            "max_position_embeddings": 32768,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 1000000.0,
+            "torch_dtype": "bfloat16"
+        }"#;
+
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        assert_eq!(config.detect_architecture(), Some(Architecture::Qwen2));
+
+        let mc = config.to_model_config().unwrap();
+        assert_eq!(mc.hidden_size, 1536);
+        assert_eq!(mc.num_kv_heads, 2);
+        assert_eq!(mc.dtype, DType::BF16);
+        assert_eq!(mc.head_dim, 128);
+    }
+
+    #[test]
+    fn parse_smollm_config() {
+        // SmolLM-135M uses llama architecture
+        let json = r#"{
+            "model_type": "llama",
+            "architectures": ["LlamaForCausalLM"],
+            "hidden_size": 576,
+            "intermediate_size": 1536,
+            "num_hidden_layers": 30,
+            "num_attention_heads": 9,
+            "num_key_value_heads": 3,
+            "vocab_size": 49152,
+            "max_position_embeddings": 2048,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "torch_dtype": "bfloat16"
+        }"#;
+
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        let mc = config.to_model_config().unwrap();
+        assert_eq!(mc.architecture, Architecture::Llama);
+        assert_eq!(mc.hidden_size, 576);
+        assert_eq!(mc.head_dim, 64);
+    }
+
+    #[test]
+    fn detect_architecture_from_architectures_field() {
+        let json = r#"{
+            "architectures": ["MistralForCausalLM"],
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 32
+        }"#;
+
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        assert_eq!(config.detect_architecture(), Some(Architecture::Mistral));
+    }
+
+    #[test]
+    fn defaults_for_missing_fields() {
+        let json = r#"{
+            "model_type": "llama",
+            "hidden_size": 512,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 8
+        }"#;
+
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        let mc = config.to_model_config().unwrap();
+        // num_kv_heads defaults to num_attention_heads
+        assert_eq!(mc.num_kv_heads, 8);
+        // intermediate_size defaults to hidden_size * 4
+        assert_eq!(mc.intermediate_size, 2048);
+        // vocab_size defaults to 32000
+        assert_eq!(mc.vocab_size, 32000);
+        // max_seq_len defaults to 2048
+        assert_eq!(mc.max_seq_len, 2048);
+        // dtype defaults to F16
+        assert_eq!(mc.dtype, DType::F16);
+    }
+
+    #[test]
+    fn unknown_architecture_returns_none() {
+        let json = r#"{"model_type": "unknown_arch"}"#;
+        let config = HFConfig::from_json(json.as_bytes()).unwrap();
+        assert_eq!(config.detect_architecture(), None);
+    }
+}

--- a/crates/forgellm-frontend/src/lib.rs
+++ b/crates/forgellm-frontend/src/lib.rs
@@ -4,8 +4,10 @@
 //! constructing the intermediate representation (IR) used by the
 //! optimizer and code generation backends.
 
+pub mod config;
 pub mod gguf;
 pub mod ir;
+pub mod safetensors;
 
 /// Re-export core IR types at the crate root.
 pub use ir::*;

--- a/crates/forgellm-frontend/src/safetensors.rs
+++ b/crates/forgellm-frontend/src/safetensors.rs
@@ -1,0 +1,250 @@
+//! SafeTensors file format parser.
+//!
+//! SafeTensors is a simple, safe format for storing tensors.
+//! Format: 8-byte LE header size, then JSON header, then raw tensor data.
+//!
+//! The JSON header maps tensor names to {dtype, shape, data_offsets}.
+
+use std::collections::HashMap;
+use std::io::{self, Read, Seek};
+
+use serde::Deserialize;
+
+use crate::ir::DType;
+
+/// Parsed SafeTensors file (metadata + tensor descriptors, no raw data).
+#[derive(Debug, Clone)]
+pub struct SafeTensorsFile {
+    pub tensors: Vec<SafeTensorInfo>,
+    /// Byte offset where tensor data begins (after the JSON header).
+    pub data_offset: u64,
+    /// Optional metadata from the header (e.g., format version).
+    pub metadata: HashMap<String, String>,
+}
+
+/// Descriptor for a single tensor in a SafeTensors file.
+#[derive(Debug, Clone)]
+pub struct SafeTensorInfo {
+    pub name: String,
+    pub dtype: DType,
+    pub shape: Vec<usize>,
+    /// Byte range within the data section [start, end).
+    pub data_start: usize,
+    pub data_end: usize,
+}
+
+impl SafeTensorInfo {
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    pub fn data_size(&self) -> usize {
+        self.data_end - self.data_start
+    }
+}
+
+/// Raw JSON structure for a tensor entry in the SafeTensors header.
+#[derive(Debug, Deserialize)]
+struct RawTensorEntry {
+    dtype: String,
+    shape: Vec<usize>,
+    data_offsets: [usize; 2],
+}
+
+/// Errors that can occur when parsing a SafeTensors file.
+#[derive(Debug, thiserror::Error)]
+pub enum SafeTensorsError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("header size {0} exceeds maximum allowed (100MB)")]
+    HeaderTooLarge(u64),
+
+    #[error("unknown dtype: {0}")]
+    UnknownDType(String),
+}
+
+/// Maximum header size (100MB) to prevent OOM on malformed files.
+const MAX_HEADER_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Parse a SafeTensors dtype string to our IR DType.
+fn parse_dtype(s: &str) -> Result<DType, SafeTensorsError> {
+    match s {
+        "F32" => Ok(DType::F32),
+        "F16" => Ok(DType::F16),
+        "BF16" => Ok(DType::BF16),
+        "I32" => Ok(DType::I32),
+        "I64" => Ok(DType::I64),
+        "F64" => Ok(DType::I64), // No f64 in our IR; treat as i64 for storage size
+        "U8" | "I8" | "BOOL" => Ok(DType::I32), // Small types mapped to i32
+        "F8_E4M3" => Ok(DType::F8E4M3),
+        "F8_E5M2" => Ok(DType::F8E5M2),
+        _ => Err(SafeTensorsError::UnknownDType(s.to_string())),
+    }
+}
+
+/// Parse a SafeTensors file from a reader.
+///
+/// Reads the header to get tensor metadata. Does NOT read tensor data.
+pub fn parse<R: Read + Seek>(mut reader: R) -> Result<SafeTensorsFile, SafeTensorsError> {
+    // Read 8-byte header size (little-endian u64)
+    let mut size_buf = [0u8; 8];
+    reader.read_exact(&mut size_buf)?;
+    let header_size = u64::from_le_bytes(size_buf);
+
+    if header_size > MAX_HEADER_SIZE {
+        return Err(SafeTensorsError::HeaderTooLarge(header_size));
+    }
+
+    // Read JSON header
+    let mut header_buf = vec![0u8; header_size as usize];
+    reader.read_exact(&mut header_buf)?;
+
+    let raw: HashMap<String, serde_json::Value> = serde_json::from_slice(&header_buf)?;
+
+    let mut tensors = Vec::new();
+    let mut metadata = HashMap::new();
+
+    for (key, value) in &raw {
+        if key == "__metadata__" {
+            // Extract metadata as string map
+            if let Some(obj) = value.as_object() {
+                for (mk, mv) in obj {
+                    if let Some(s) = mv.as_str() {
+                        metadata.insert(mk.clone(), s.to_string());
+                    }
+                }
+            }
+            continue;
+        }
+
+        let entry: RawTensorEntry = serde_json::from_value(value.clone())?;
+        let dtype = parse_dtype(&entry.dtype)?;
+
+        tensors.push(SafeTensorInfo {
+            name: key.clone(),
+            dtype,
+            shape: entry.shape,
+            data_start: entry.data_offsets[0],
+            data_end: entry.data_offsets[1],
+        });
+    }
+
+    // Sort tensors by data offset for deterministic ordering
+    tensors.sort_by_key(|t| t.data_start);
+
+    let data_offset = 8 + header_size;
+
+    Ok(SafeTensorsFile {
+        tensors,
+        data_offset,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Build a minimal SafeTensors file in memory.
+    fn build_safetensors_bytes(header_json: &str) -> Vec<u8> {
+        let header_bytes = header_json.as_bytes();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(header_bytes.len() as u64).to_le_bytes());
+        buf.extend_from_slice(header_bytes);
+        // Append some dummy tensor data
+        buf.extend_from_slice(&[0u8; 256]);
+        buf
+    }
+
+    #[test]
+    fn parse_simple_safetensors() {
+        let header = r#"{
+            "weight": {"dtype": "F16", "shape": [768, 768], "data_offsets": [0, 1179648]}
+        }"#;
+        let bytes = build_safetensors_bytes(header);
+
+        let file = parse(Cursor::new(bytes)).unwrap();
+        assert_eq!(file.tensors.len(), 1);
+        assert_eq!(file.tensors[0].name, "weight");
+        assert_eq!(file.tensors[0].dtype, DType::F16);
+        assert_eq!(file.tensors[0].shape, vec![768, 768]);
+        assert_eq!(file.tensors[0].data_start, 0);
+        assert_eq!(file.tensors[0].data_end, 1179648);
+    }
+
+    #[test]
+    fn parse_multiple_tensors() {
+        let header = r#"{
+            "__metadata__": {"format": "pt"},
+            "model.embed_tokens.weight": {"dtype": "F32", "shape": [32000, 2048], "data_offsets": [0, 262144000]},
+            "model.layers.0.self_attn.q_proj.weight": {"dtype": "F16", "shape": [2048, 2048], "data_offsets": [262144000, 270532608]}
+        }"#;
+        let bytes = build_safetensors_bytes(header);
+
+        let file = parse(Cursor::new(bytes)).unwrap();
+        assert_eq!(file.tensors.len(), 2);
+        assert_eq!(file.metadata.get("format"), Some(&"pt".to_string()));
+
+        // Should be sorted by data offset
+        assert_eq!(file.tensors[0].name, "model.embed_tokens.weight");
+        assert_eq!(file.tensors[0].dtype, DType::F32);
+        assert_eq!(
+            file.tensors[1].name,
+            "model.layers.0.self_attn.q_proj.weight"
+        );
+    }
+
+    #[test]
+    fn parse_bf16_tensors() {
+        let header =
+            r#"{"w": {"dtype": "BF16", "shape": [1024, 512], "data_offsets": [0, 1048576]}}"#;
+        let bytes = build_safetensors_bytes(header);
+
+        let file = parse(Cursor::new(bytes)).unwrap();
+        assert_eq!(file.tensors[0].dtype, DType::BF16);
+    }
+
+    #[test]
+    fn reject_too_large_header() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(MAX_HEADER_SIZE + 1).to_le_bytes());
+        let result = parse(Cursor::new(bytes));
+        assert!(matches!(result, Err(SafeTensorsError::HeaderTooLarge(_))));
+    }
+
+    #[test]
+    fn reject_unknown_dtype() {
+        let header = r#"{"w": {"dtype": "COMPLEX128", "shape": [10], "data_offsets": [0, 100]}}"#;
+        let bytes = build_safetensors_bytes(header);
+        let result = parse(Cursor::new(bytes));
+        assert!(matches!(result, Err(SafeTensorsError::UnknownDType(_))));
+    }
+
+    #[test]
+    fn tensor_info_helpers() {
+        let t = SafeTensorInfo {
+            name: "test".into(),
+            dtype: DType::F32,
+            shape: vec![32, 64],
+            data_start: 0,
+            data_end: 8192,
+        };
+        assert_eq!(t.numel(), 2048);
+        assert_eq!(t.data_size(), 8192);
+    }
+
+    #[test]
+    fn data_offset_calculation() {
+        let header = r#"{"w": {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}}"#;
+        let header_len = header.len() as u64;
+        let bytes = build_safetensors_bytes(header);
+
+        let file = parse(Cursor::new(bytes)).unwrap();
+        assert_eq!(file.data_offset, 8 + header_len);
+    }
+}


### PR DESCRIPTION
## Summary
- SafeTensors format parser: reads JSON header, extracts tensor metadata (name, dtype, shape, data offsets), supports all common dtypes (F32, F16, BF16, F8)
- HuggingFace `config.json` parser: detects architecture type (Llama, Qwen2, Mistral, Phi3, Gemma, StableLM) from both `model_type` and `architectures` fields
- Converts HF config to IR `ModelConfig` with sensible defaults for missing fields
- Includes test for sub-1B model configs (SmolLM-135M)

## Test plan
- [x] 7 SafeTensors tests: simple/multi tensor parsing, BF16, error cases, data offset calculation
- [x] 6 config tests: Llama, Qwen2, SmolLM-135M, architecture detection, defaults, unknown arch
- [x] 32 total workspace tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean
- [ ] CI passes