### PR TITLE
perf: memory-mapped weight loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
 name = "forgellm-frontend"
 version = "0.1.0"
 dependencies = [
+ "memmap2",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -484,6 +485,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Tokenizer
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 
+# Memory mapping
+memmap2 = "0.9"
+
 # Testing
 pretty_assertions = "1"

--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -350,13 +350,11 @@ fn cmd_run(
     let graph =
         graph_builder::build_graph(&config).with_context(|| "failed to build computation graph")?;
 
-    // Load weights
+    // Load weights (mmap)
     eprintln!("Loading weights...");
     let start = Instant::now();
-    let data = fs::read(model_path).with_context(|| format!("failed to read {model_path}"))?;
-    let gguf_file = gguf::parse(Cursor::new(&data)).with_context(|| "failed to parse GGUF file")?;
-    let weights = weight_loader::load_all(&mut Cursor::new(&data), &gguf_file)
-        .with_context(|| "failed to load weights")?;
+    let (_gguf_file, weights) =
+        weight_loader::load_from_file(model_path).with_context(|| "failed to load weights")?;
     eprintln!(
         "Loaded {} tensors ({:.1} MB) in {:.1}s",
         weights.len(),
@@ -477,10 +475,8 @@ fn cmd_serve(model_path: &str, tokenizer_path: &str, port: u16) -> Result<()> {
     let graph =
         graph_builder::build_graph(&config).with_context(|| "failed to build computation graph")?;
 
-    let data = fs::read(model_path).with_context(|| format!("failed to read {model_path}"))?;
-    let gguf_file = gguf::parse(Cursor::new(&data)).with_context(|| "failed to parse GGUF file")?;
-    let weights = weight_loader::load_all(&mut Cursor::new(&data), &gguf_file)
-        .with_context(|| "failed to load weights")?;
+    let (_gguf_file, weights) =
+        weight_loader::load_from_file(model_path).with_context(|| "failed to load weights")?;
 
     eprintln!(
         "Model loaded: {} | {} layers | {:.0} MB",

--- a/crates/forgellm-frontend/Cargo.toml
+++ b/crates/forgellm-frontend/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+memmap2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/forgellm-frontend/src/weight_loader.rs
+++ b/crates/forgellm-frontend/src/weight_loader.rs
@@ -5,8 +5,9 @@
 
 use std::collections::HashMap;
 use std::io::{self, Read, Seek, SeekFrom};
+use std::path::Path;
 
-use crate::gguf::{GGMLType, GGUFFile, GGUFTensorInfo};
+use crate::gguf::{self, GGMLType, GGUFFile, GGUFTensorInfo};
 
 /// Loaded model weights — all tensors dequantized to f32.
 #[derive(Debug, Clone)]
@@ -77,6 +78,41 @@ pub fn load_all<R: Read + Seek>(
     }
 
     Ok(ModelWeights { tensors })
+}
+
+/// Load all tensors from a GGUF file using memory mapping.
+///
+/// This is faster than `load_all` because it avoids reading the entire
+/// file into a Vec first — the OS maps it directly into virtual memory.
+pub fn load_from_file(path: impl AsRef<Path>) -> Result<(GGUFFile, ModelWeights), WeightLoadError> {
+    let file = std::fs::File::open(path.as_ref())?;
+    let mmap = unsafe { memmap2::Mmap::map(&file)? };
+    let mut cursor = io::Cursor::new(&mmap[..]);
+
+    let gguf = gguf::parse(&mut cursor).map_err(|e| WeightLoadError::Io(io::Error::other(e)))?;
+
+    let mut tensors = HashMap::with_capacity(gguf.tensors.len());
+    for tensor_info in &gguf.tensors {
+        let data_offset = gguf.tensor_data_offset + tensor_info.offset;
+        let data_size = tensor_info.data_size() as usize;
+        let numel = tensor_info.numel() as usize;
+
+        let start = data_offset as usize;
+        let end = start + data_size;
+        if end > mmap.len() {
+            return Err(WeightLoadError::Io(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("tensor {} extends past end of file", tensor_info.name),
+            )));
+        }
+
+        let raw = &mmap[start..end];
+        let data = dequantize(raw, tensor_info.ggml_type, numel)?;
+        let hf_name = gguf_name_to_hf(&tensor_info.name);
+        tensors.insert(hf_name, data);
+    }
+
+    Ok((gguf, ModelWeights { tensors }))
 }
 
 /// Remap GGUF tensor names to HuggingFace convention.


### PR DESCRIPTION
## Summary
- Add `load_from_file()` using `memmap2` for memory-mapped GGUF loading
- Avoids double-buffering (no `fs::read` + parse — maps directly)
- Dequantizes tensors from mapped memory
- CLI `run`, `serve` commands updated to use mmap loader

## Test plan
- [x] Build + clippy + fmt clean
- [x] Tested with SmolLM-135M and Qwen2.5-0.5B
- [ ] CI passes