### PR TITLE
feat: GeLU activation + --system/--chat flags for forge run

### DIFF
--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -77,6 +77,14 @@ enum Commands {
         /// Repetition penalty (1.0 = disabled, >1.0 = penalize repeats)
         #[arg(long, default_value = "1.1")]
         repeat_penalty: f32,
+
+        /// System prompt (enables chat template formatting)
+        #[arg(long)]
+        system: Option<String>,
+
+        /// Use chat template formatting
+        #[arg(long)]
+        chat: bool,
     },
 
     /// Benchmark model inference performance
@@ -143,16 +151,34 @@ fn main() -> Result<()> {
             top_k,
             top_p,
             repeat_penalty,
-        } => cmd_run(
-            &model,
-            &tokenizer,
-            &prompt,
-            max_tokens,
-            temperature,
-            top_k,
-            top_p,
-            repeat_penalty,
-        )?,
+            system,
+            chat,
+        } => {
+            // Apply chat template if --chat or --system is provided
+            let effective_prompt = if chat || system.is_some() {
+                let config = load_model_config(&model)?;
+                let template = forgellm_runtime::chat::ChatTemplate::from_architecture(
+                    &config.architecture.to_string(),
+                );
+                if let Some(ref sys) = system {
+                    template.format_with_system(sys, &prompt)
+                } else {
+                    template.format_prompt(&prompt)
+                }
+            } else {
+                prompt.clone()
+            };
+            cmd_run(
+                &model,
+                &tokenizer,
+                &effective_prompt,
+                max_tokens,
+                temperature,
+                top_k,
+                top_p,
+                repeat_penalty,
+            )?
+        }
 
         Commands::Bench {
             model,

--- a/crates/forgellm-runtime/src/kernels.rs
+++ b/crates/forgellm-runtime/src/kernels.rs
@@ -130,6 +130,15 @@ pub fn silu(output: &mut [f32], input: &[f32]) {
     }
 }
 
+/// GeLU activation (approximate): 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+pub fn gelu(output: &mut [f32], input: &[f32]) {
+    const SQRT_2_OVER_PI: f32 = 0.797_884_6; // sqrt(2/pi)
+    for (o, &x) in output.iter_mut().zip(input.iter()) {
+        let inner = SQRT_2_OVER_PI * (x + 0.044715 * x * x * x);
+        *o = 0.5 * x * (1.0 + inner.tanh());
+    }
+}
+
 /// Optimized elementwise multiply
 pub fn elementwise_mul(output: &mut [f32], a: &[f32], b: &[f32]) {
     for i in 0..a.len() {


### PR DESCRIPTION
## Summary
- **GeLU kernel**: approximate GeLU activation for Gemma models
- **--system flag**: provide system prompt, auto-formatted with chat template
- **--chat flag**: enable chat template formatting without system prompt
- Template auto-detected from model architecture (ChatML for SmolLM/Qwen, Llama3, etc.)

## Usage
\`\`\`bash
forge run --model model.gguf --tokenizer tokenizer.json \
  --chat --system "You are a helpful assistant" \
  --prompt "What is Rust?"
\`\`\`

## Test plan
- [x] Build + clippy + fmt clean
- [x] 100 workspace tests pass
- [ ] CI passes