### PR TITLE
docs: update benchmarks and models with verified results

### DIFF
--- a/docs/src/benchmarks/results.md
+++ b/docs/src/benchmarks/results.md
@@ -1,36 +1,67 @@
 # Performance Results
 
-## SmolLM2-135M-Instruct (Q8_0)
+## Verified Models
 
-Tested on Apple Silicon (M-series), reference interpreter (naive f32, no SIMD).
+All benchmarks on Apple Silicon (M-series), optimized kernels (unrolled matmul).
+
+### SmolLM2-135M-Instruct (Q8_0)
 
 | Metric | Value |
 |--------|-------|
-| Model | SmolLM2-135M-Instruct |
-| Quantization | Q8_0 |
 | Parameters | 135M |
-| Weight memory | 538 MB (dequantized to f32) |
-| Weight load time | 0.1s |
-| Prefill throughput | ~20 tok/s |
-| Generation throughput | ~21.6 tok/s |
+| Architecture | Llama |
+| Quantization | Q8_0 |
+| Weight memory | 538 MB |
+| Avg prefill | 46.0 tok/s |
+| Avg generate | **46.3 tok/s** |
 
-### Sample Output
+### SmolLM2-360M-Instruct (Q8_0)
+
+| Metric | Value |
+|--------|-------|
+| Parameters | 360M |
+| Architecture | Llama |
+| Quantization | Q8_0 |
+| Weight memory | 1,447 MB |
+| Avg generate | **17.5 tok/s** |
+
+### Qwen2.5-0.5B-Instruct (Q8_0)
+
+| Metric | Value |
+|--------|-------|
+| Parameters | 494M |
+| Architecture | Qwen2 |
+| Quantization | Q8_0 |
+| Weight memory | 2,521 MB |
+| Avg generate | **12.0 tok/s** |
+
+## Sample Output
 
 ```
-Prompt: "The meaning of life is"
+$ forge run --model SmolLM2-135M-Instruct-Q8_0.gguf \
+            --tokenizer tokenizer.json \
+            --prompt "The meaning of life is"
 
 The meaning of life is a complex and multifaceted concept that has been
 debated by philosophers, scientists, and theologians for centuries. At its
 core, the question of what it means to be human...
+
+Prefill: 5 tokens in 0.13s (37.3 tok/s)
+Generate: 65 tokens in 1.42s (45.7 tok/s)
 ```
 
-## Performance Roadmap
+## Performance History
 
-The current numbers are from the reference interpreter — a naive, unoptimized f32 implementation. Planned optimizations:
+| Version | SmolLM-135M Q8_0 | Improvement |
+|---------|------------------|-------------|
+| v0.1 (reference interpreter) | 21.6 tok/s | baseline |
+| v0.2 (unrolled matmul) | **46.3 tok/s** | **2.1x** |
+
+## Roadmap
 
 | Optimization | Expected Speedup |
 |-------------|-----------------|
-| SIMD matmul (AVX2/NEON) | 3-5x |
+| ARM NEON SIMD intrinsics | 2-3x |
 | Operator fusion | 1.5-2x |
 | Quantized inference (skip dequant) | 2-3x |
 | Static memory planning | 1.2x |

--- a/docs/src/getting-started/models.md
+++ b/docs/src/getting-started/models.md
@@ -6,13 +6,13 @@ ForgeLLM supports Llama-family transformer architectures. Any model in GGUF form
 
 | Model | Params | Architecture | Quantization | Status |
 |-------|--------|-------------|--------------|--------|
-| SmolLM2-135M-Instruct | 135M | Llama | Q8_0 | Verified |
-| SmolLM2-360M-Instruct | 360M | Llama | Q8_0 | Expected |
+| SmolLM2-135M-Instruct | 135M | Llama | Q8_0 | **Verified** (46.3 tok/s) |
+| SmolLM2-360M-Instruct | 360M | Llama | Q8_0 | **Verified** (17.5 tok/s) |
 | SmolLM2-1.7B-Instruct | 1.7B | Llama | Q8_0, Q4_0 | Expected |
 | TinyLlama-1.1B | 1.1B | Llama | Q8_0, Q4_0 | Expected |
 | Llama-3.2-1B-Instruct | 1B | Llama | Q8_0, Q4_0 | Expected |
 | Llama-3.2-3B-Instruct | 3B | Llama | Q8_0, Q4_0 | Expected |
-| Qwen2.5-0.5B-Instruct | 0.5B | Qwen2 | Q8_0 | Expected |
+| Qwen2.5-0.5B-Instruct | 0.5B | Qwen2 | Q8_0 | **Verified** (12.0 tok/s) |
 | Qwen2.5-1.5B-Instruct | 1.5B | Qwen2 | Q8_0, Q4_0 | Expected |
 | Mistral-7B-Instruct | 7B | Mistral | Q4_0 | Expected |
 
@@ -24,8 +24,14 @@ ForgeLLM supports Llama-family transformer architectures. Any model in GGUF form
 | F16 | Half precision | ~2 GB |
 | BF16 | Brain floating point | ~2 GB |
 | Q8_0 | 8-bit quantized | ~1 GB |
+| Q8_K | 8-bit K-quant | ~1 GB |
+| Q6_K | 6-bit K-quant | ~0.82 GB |
+| Q5_K | 5-bit K-quant | ~0.69 GB |
 | Q4_0 | 4-bit quantized | ~0.5 GB |
 | Q4_1 | 4-bit with min | ~0.55 GB |
+| Q4_K | 4-bit K-quant | ~0.56 GB |
+| Q3_K | 3-bit K-quant | ~0.43 GB |
+| Q2_K | 2-bit K-quant | ~0.33 GB |
 
 ## Adding New Architectures
 


### PR DESCRIPTION
## Summary
- Update benchmark results with 3 verified models and actual throughput numbers
- Performance history section showing 2.1x improvement from optimized kernels
- All 12 supported quantization formats listed (including K-quants)
- Mark verified models with actual tok/s numbers

## Test plan
- [x] `mdbook build docs` succeeds
- [ ] CI passes