### PR TITLE
feat: streaming SSE in forge serve

### DIFF
--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -589,6 +589,31 @@ fn cmd_serve(model_path: &str, tokenizer_path: &str, port: u16) -> Result<()> {
             }
 
             ("POST", "/v1/completions") => {
+                // Check for streaming
+                let is_stream = serde_json::from_slice::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|v| v["stream"].as_bool())
+                    .unwrap_or(false);
+
+                if is_stream {
+                    // Stream response directly
+                    let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\n\r\n";
+                    stream.write_all(header.as_bytes())?;
+                    if let Err(e) = handle_completion_stream(
+                        &body,
+                        &config,
+                        &graph,
+                        &weights,
+                        &tokenizer,
+                        &mut stream,
+                    ) {
+                        let err_data = format!("data: {{\"error\":\"{e}\"}}\n\n");
+                        let _ = stream.write_all(err_data.as_bytes());
+                    }
+                    let _ = stream.write_all(b"data: [DONE]\n\n");
+                    continue;
+                }
+
                 match handle_completion(&body, &config, &graph, &weights, &tokenizer) {
                     Ok(resp) => ("200 OK", resp),
                     Err(e) => (
@@ -927,4 +952,76 @@ fn handle_chat_completion(
     });
 
     Ok(response.to_string())
+}
+
+fn handle_completion_stream(
+    body: &[u8],
+    config: &ModelConfig,
+    graph: &forgellm_frontend::ir::Graph,
+    weights: &weight_loader::ModelWeights,
+    tokenizer: &Tokenizer,
+    stream: &mut impl Write,
+) -> Result<()> {
+    let req: serde_json::Value = serde_json::from_slice(body)?;
+    let prompt = req["prompt"].as_str().unwrap_or("Hello");
+    let max_tokens = req["max_tokens"].as_u64().unwrap_or(64) as usize;
+    let temperature = req["temperature"].as_f64().unwrap_or(0.0) as f32;
+
+    let sampling_config = if temperature == 0.0 {
+        sampling::SamplingConfig::greedy()
+    } else {
+        sampling::SamplingConfig {
+            temperature,
+            top_k: req["top_k"].as_u64().unwrap_or(0) as usize,
+            top_p: req["top_p"].as_f64().unwrap_or(1.0) as f32,
+            repetition_penalty: 1.1,
+        }
+    };
+
+    let prompt_tokens = tokenizer.encode(prompt)?;
+    let mut cache = KVCache::with_capacity(
+        config.num_layers,
+        config.num_kv_heads,
+        config.head_dim,
+        config
+            .max_seq_len
+            .min(prompt_tokens.len() + max_tokens + 16),
+    );
+
+    // Prefill
+    let mut next_token = 0u32;
+    for (pos, &token) in prompt_tokens.iter().enumerate() {
+        let logits = interpreter::forward(token, pos, graph, weights, &mut cache);
+        cache.advance();
+        next_token = sampling::sample(&logits, &sampling_config, pos as u64);
+    }
+
+    // Generate and stream
+    let eos_id = tokenizer.eos_token_id();
+    let mut all_tokens: Vec<u32> = prompt_tokens;
+
+    for i in 0..max_tokens {
+        let text = tokenizer.decode_one(next_token).unwrap_or_default();
+        all_tokens.push(next_token);
+
+        let chunk = serde_json::json!({
+            "id": "cmpl-forge",
+            "object": "text_completion",
+            "choices": [{"text": text, "index": 0, "finish_reason": serde_json::Value::Null}]
+        });
+        write!(stream, "data: {}\n\n", chunk)?;
+        stream.flush()?;
+
+        if eos_id.is_some_and(|eos| next_token == eos) {
+            break;
+        }
+
+        let pos = all_tokens.len() - 1;
+        let mut logits = interpreter::forward(next_token, pos, graph, weights, &mut cache);
+        cache.advance();
+        sampling::apply_repetition_penalty(&mut logits, &all_tokens, 1.1);
+        next_token = sampling::sample(&logits, &sampling_config, (i + 1) as u64);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Add \`stream: true\` support for POST /v1/completions
- Sends SSE events with one token per event in real-time
- OpenAI-compatible streaming format (data: {...}\n\n + data: [DONE])
- Non-streaming mode unchanged

## Usage
\`\`\`bash
curl -N http://localhost:8080/v1/completions -d '{"prompt":"Hello","max_tokens":32,"stream":true}'
\`\`\`

## Test plan
- [x] Build + clippy clean
- [ ] CI passes