### PR TITLE
feat: multi-stop-token support

### DIFF
--- a/crates/forgellm-runtime/src/tokenizer.rs
+++ b/crates/forgellm-runtime/src/tokenizer.rs
@@ -96,6 +96,28 @@ impl Tokenizer {
             .or_else(|| self.token_to_id("<|endoftext|>"))
             .or_else(|| self.token_to_id("<|im_end|>"))
     }
+
+    /// Get all stop token IDs (EOS + chat-specific stop tokens).
+    /// Used to detect when generation should stop.
+    pub fn stop_token_ids(&self) -> Vec<u32> {
+        let candidates = [
+            "</s>",
+            "<|end_of_text|>",
+            "<|endoftext|>",
+            "<|im_end|>",
+            "<|eot_id|>",
+            "<|end|>",
+        ];
+        candidates
+            .iter()
+            .filter_map(|&token| self.token_to_id(token))
+            .collect()
+    }
+
+    /// Check if a token ID is a stop token.
+    pub fn is_stop_token(&self, token_id: u32) -> bool {
+        self.stop_token_ids().contains(&token_id)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- \`stop_token_ids()\` returns all stop tokens for the model
- \`is_stop_token()\` for easy checking in generation loops
- Covers: \`</s>\`, \`<|end_of_text|>\`, \`<|im_end|>\`, \`<|eot_id|>\`, \`<|end|>\`

## Test plan
- [x] Build + clippy clean
- [ ] CI passes