### PR TITLE
perf: 2.9x AOT speedup — upgrade dot_f32 + tune Rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forgellm-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-cpu"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-gpu"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-frontend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "memmap2",
  "pretty_assertions",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-optimizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",

--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -7,6 +7,7 @@ Performance tracking across versions. All benchmarks run on SmolLM2-135M-Instruc
 | Version | Date | Interpreter (tok/s) | AOT (tok/s) | AOT Build (s) | Binary Size | System |
 |---------|------|---------------------|-------------|---------------|-------------|--------|
 | v0.2.0 | 2026-04-09 | 119.7 | 36.2 avg (best: 40.2) | 29s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
+| v0.3.0-dev | 2026-04-09 | 119.7 | **105.2** avg (best: 105.5) | 32s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 
 ## Analysis
 
@@ -23,10 +24,16 @@ First release with AOT compilation. Key observations:
 
 ### Improvement targets for v0.3.0
 
-1. **Inline NEON intrinsics in generated matmul** — match interpreter's dot_f32 performance
-2. **Reduce Rayon overhead** — tune parallelism threshold for small models
+1. **Inline NEON intrinsics in generated matmul** — match interpreter's dot_f32 performance ✅ DONE
+2. **Reduce Rayon overhead** — tune parallelism threshold for small models ✅ DONE (1024 → 4096)
 3. **Optimize logits projection** — largest single matmul (576 x 49152)
 4. **Profile-guided optimization (PGO)** — use cargo-pgo for the AOT binary
+
+### v0.3.0-dev Results
+
+- **AOT improved 2.9x: 36.2 → 105.2 tok/s** (88% of interpreter)
+- Upgraded `dot_f32` to 4 NEON accumulators with 16-element unrolled inner loop
+- Bumped Rayon parallelism threshold from 1024 to 4096 (eliminated overhead for SmolLM matmuls)
 
 ## How to Run
 

--- a/benchmarks/results/0.3.0-dev.json
+++ b/benchmarks/results/0.3.0-dev.json
@@ -1,0 +1,42 @@
+{
+  "version": "0.3.0-dev",
+  "date": "2026-04-09T23:30:00Z",
+  "system": {
+    "os": "Darwin",
+    "arch": "arm64",
+    "cpu": "Apple M5 Pro",
+    "cores": "18"
+  },
+  "model": {
+    "name": "SmolLM2-135M-Instruct",
+    "quant": "Q8_0",
+    "params": "135M",
+    "layers": 30,
+    "hidden_size": 576
+  },
+  "benchmarks": {
+    "interpreter": {
+      "generate_tok_s_avg": 119.7,
+      "num_tokens": 64,
+      "runs": 3
+    },
+    "aot": {
+      "generate_tok_s_avg": 105.2,
+      "generate_tok_s_best": 105.5,
+      "generate_tok_s_runs": [105.1, 105.0, 105.5],
+      "prefill_tok_s_avg": 93.3,
+      "num_tokens": 57,
+      "runs": 3,
+      "build_time_s": 32,
+      "binary_size_mb": 3.8
+    }
+  },
+  "improvements_vs_v0_2_0": {
+    "aot_speedup": "2.9x (36.2 → 105.2 tok/s)",
+    "vs_interpreter": "88% (was 30%)"
+  },
+  "changes": [
+    "Upgraded dot_f32 to 4 NEON accumulators with 16-element unrolled inner loop",
+    "Bumped Rayon parallelism threshold 1024 → 4096"
+  ]
+}

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -117,7 +117,7 @@ fn emit_kernel_functions(code: &mut String) -> Result<(), CodegenError> {
     // Emit all kernels as a template string — includes NEON SIMD with scalar fallback
     code.push_str(
         r#"
-// --- NEON SIMD dot product ---
+// --- NEON SIMD dot product (4 accumulators, 16-element unrolled) ---
 #[cfg(target_arch = "aarch64")]
 #[inline]
 fn dot_f32(a: &[f32], b: &[f32], len: usize) -> f32 {
@@ -125,14 +125,21 @@ fn dot_f32(a: &[f32], b: &[f32], len: usize) -> f32 {
     unsafe {
         let mut s0 = vdupq_n_f32(0.0);
         let mut s1 = vdupq_n_f32(0.0);
-        let chunks = len / 8;
+        let mut s2 = vdupq_n_f32(0.0);
+        let mut s3 = vdupq_n_f32(0.0);
+        let chunks = len / 16;
         for i in 0..chunks {
-            let base = i * 8;
+            let base = i * 16;
             s0 = vfmaq_f32(s0, vld1q_f32(a.as_ptr().add(base)), vld1q_f32(b.as_ptr().add(base)));
             s1 = vfmaq_f32(s1, vld1q_f32(a.as_ptr().add(base+4)), vld1q_f32(b.as_ptr().add(base+4)));
+            s2 = vfmaq_f32(s2, vld1q_f32(a.as_ptr().add(base+8)), vld1q_f32(b.as_ptr().add(base+8)));
+            s3 = vfmaq_f32(s3, vld1q_f32(a.as_ptr().add(base+12)), vld1q_f32(b.as_ptr().add(base+12)));
         }
-        let mut r = vaddvq_f32(vaddq_f32(s0, s1));
-        for i in (chunks*8)..len { r += *a.get_unchecked(i) * *b.get_unchecked(i); }
+        s0 = vaddq_f32(s0, s1);
+        s2 = vaddq_f32(s2, s3);
+        s0 = vaddq_f32(s0, s2);
+        let mut r = vaddvq_f32(s0);
+        for i in (chunks*16)..len { r += *a.get_unchecked(i) * *b.get_unchecked(i); }
         r
     }
 }
@@ -443,9 +450,9 @@ fn emit_specialized_matmul_functions(
     writeln!(code, "// All dimensions baked in at compile time — no runtime size parameters.")?;
     writeln!(code)?;
 
-    // Threshold for parallelization: only parallelize if N >= 1024
-    // (otherwise Rayon overhead dominates the compute)
-    let par_threshold = 1024;
+    // Threshold for parallelization: only parallelize if N >= 4096
+    // (otherwise Rayon overhead dominates the compute for small matmuls)
+    let par_threshold = 4096;
 
     for &(k, n) in &matmul_shapes(config) {
         writeln!(code, "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]")?;


### PR DESCRIPTION
## Summary
- Upgraded `dot_f32` in generated code to use **4 NEON accumulators with 16-element unrolled inner loop**, matching the runtime kernels
- Bumped Rayon parallelism threshold from 1024 → 4096 (eliminates overhead for SmolLM-sized matmuls)

## Benchmark Results (SmolLM2-135M Q8_0, Apple M5 Pro 18c)

| Version | AOT (tok/s) | vs Interpreter |
|---------|-------------|----------------|
| v0.2.0 | 36.2 | 30% |
| **v0.3.0-dev** | **105.2** | **88%** |

**2.9x speedup** in the AOT binary. The remaining 12% gap is likely from
the logits projection overhead and prefill code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)