### PR TITLE
perf: 4-way row unrolling in specialized matmul

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -8,6 +8,7 @@ Performance tracking across versions. All benchmarks run on SmolLM2-135M-Instruc
 |---------|------|---------------------|-------------|---------------|-------------|--------|
 | v0.2.0 | 2026-04-09 | 119.7 | 36.2 avg (best: 40.2) | 29s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 | v0.3.0-dev | 2026-04-09 | 119.7 | **105.2** avg (best: 105.5) | 32s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
+| v0.3.0-dev2 | 2026-04-09 | 119.7 | **116.2** avg (best: 117.8) | 26s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 
 ## Analysis
 

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -474,17 +474,31 @@ fn emit_specialized_matmul_functions(
             writeln!(code, "    }});")?;
             writeln!(code, "}}")?;
         } else {
+            // Sequential with 4-way row unrolling for ILP
             writeln!(code, "#[inline]")?;
             writeln!(
                 code,
                 "fn matmul_vec_{k}x{n}(output: &mut [f32; {n}], input: &[f32; {k}], weight: &[f32]) {{"
             )?;
-            writeln!(code, "    for j in 0..{n} {{")?;
-            writeln!(
-                code,
-                "        output[j] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
-            )?;
-            writeln!(code, "    }}")?;
+            let n_chunks = n / 4;
+            let n_remainder = n % 4;
+            if n_chunks > 0 {
+                writeln!(code, "    // Process 4 output rows at a time for instruction-level parallelism")?;
+                writeln!(code, "    for chunk in 0..{n_chunks} {{")?;
+                writeln!(code, "        let j0 = chunk * 4;")?;
+                writeln!(code, "        output[j0]   = dot_f32(&input[..], &weight[j0*{k}..(j0+1)*{k}], {k});")?;
+                writeln!(code, "        output[j0+1] = dot_f32(&input[..], &weight[(j0+1)*{k}..(j0+2)*{k}], {k});")?;
+                writeln!(code, "        output[j0+2] = dot_f32(&input[..], &weight[(j0+2)*{k}..(j0+3)*{k}], {k});")?;
+                writeln!(code, "        output[j0+3] = dot_f32(&input[..], &weight[(j0+3)*{k}..(j0+4)*{k}], {k});")?;
+                writeln!(code, "    }}")?;
+            }
+            if n_remainder > 0 {
+                writeln!(code, "    // Handle remaining {n_remainder} output rows")?;
+                writeln!(code, "    let base = {} * 4;", n_chunks)?;
+                for r in 0..n_remainder {
+                    writeln!(code, "    output[base+{r}] = dot_f32(&input[..], &weight[(base+{r})*{k}..(base+{r}+1)*{k}], {k});")?;
+                }
+            }
             writeln!(code, "}}")?;
         }
         writeln!(code)?;


### PR DESCRIPTION
## Summary
- Process 4 output rows at a time in `matmul_vec_KxN` for instruction-level parallelism
- Matches the runtime kernel's approach

## Benchmark (SmolLM2-135M Q8_0, Apple M5 Pro)

| Version | AOT (tok/s) | vs Interpreter |
|---------|-------------|----------------|
| v0.2.0 | 36.2 | 30% |
| v0.3.0-dev (NEON dot) | 105.2 | 88% |
| **v0.3.0-dev2 (row ILP)** | **116.2** | **97%** |

Within 3% of interpreter performance now.