### PR TITLE
perf: AOT matches interpreter — 119.9 tok/s

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -9,6 +9,7 @@ Performance tracking across versions. All benchmarks run on SmolLM2-135M-Instruc
 | v0.2.0 | 2026-04-09 | 119.7 | 36.2 avg (best: 40.2) | 29s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 | v0.3.0-dev | 2026-04-09 | 119.7 | **105.2** avg (best: 105.5) | 32s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 | v0.3.0-dev2 | 2026-04-09 | 119.7 | **116.2** avg (best: 117.8) | 26s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
+| v0.3.0-dev3 | 2026-04-09 | 119.7 | **119.9** avg (best: 122.1) | 26s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
 
 ## Analysis
 
@@ -32,9 +33,19 @@ First release with AOT compilation. Key observations:
 
 ### v0.3.0-dev Results
 
-- **AOT improved 2.9x: 36.2 → 105.2 tok/s** (88% of interpreter)
-- Upgraded `dot_f32` to 4 NEON accumulators with 16-element unrolled inner loop
-- Bumped Rayon parallelism threshold from 1024 to 4096 (eliminated overhead for SmolLM matmuls)
+**AOT now matches interpreter performance** — 3.3x speedup vs v0.2.0:
+
+- **v0.2.0**: 36.2 tok/s (30% of interpreter)
+- **v0.3.0-dev1**: 105.2 tok/s (88% — 4-acc NEON dot_f32 + Rayon threshold tune)
+- **v0.3.0-dev2**: 116.2 tok/s (97% — 4-way row unrolling in matmul_vec_KxN)
+- **v0.3.0-dev3**: 119.9 tok/s (**100%+** — Rayon par_chunks_mut(256) for logits)
+
+Optimizations:
+1. Upgraded `dot_f32` to 4 NEON accumulators with 16-element unrolled inner loop
+2. Bumped Rayon parallelism threshold 1024 → 4096
+3. 4-way row unrolling in `matmul_vec_KxN` (matches runtime kernels)
+4. `par_chunks_mut(256)` for logits — amortizes Rayon overhead
+5. Cleaned up generated code warnings (`#![allow(dead_code, ...)]`)
 
 ## How to Run
 

--- a/benchmarks/results/0.3.0-dev3.json
+++ b/benchmarks/results/0.3.0-dev3.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.3.0-dev3",
+  "date": "2026-04-09T23:50:00Z",
+  "system": {
+    "os": "Darwin",
+    "arch": "arm64",
+    "cpu": "Apple M5 Pro",
+    "cores": "18"
+  },
+  "model": {
+    "name": "SmolLM2-135M-Instruct",
+    "quant": "Q8_0",
+    "params": "135M"
+  },
+  "benchmarks": {
+    "interpreter": {
+      "generate_tok_s_avg": 119.7
+    },
+    "aot": {
+      "generate_tok_s_avg": 119.9,
+      "generate_tok_s_best": 122.1,
+      "generate_tok_s_runs": [118.7, 118.8, 122.1],
+      "prefill_tok_s_avg": 119.8,
+      "build_time_s": 26,
+      "binary_size_mb": 3.8
+    }
+  },
+  "improvements_vs_v0_2_0": {
+    "aot_speedup": "3.3x (36.2 → 119.9 tok/s)",
+    "vs_interpreter": "100%+ (was 30%) — AOT now matches interpreter"
+  }
+}

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -58,6 +58,7 @@ fn emit_header(code: &mut String, config: &ModelConfig) -> Result<(), CodegenErr
     )?;
     writeln!(code)?;
     writeln!(code, "#![allow(clippy::excessive_precision)]")?;
+    writeln!(code, "#![allow(dead_code, unused_imports, unused_assignments)]")?;
     writeln!(code)?;
     writeln!(code, "use rayon::prelude::*;")?;
     writeln!(code)?;
@@ -313,13 +314,12 @@ pub fn softmax(values: &mut [f32]) {
     use std::arch::aarch64::*;
     // Find max using NEON
     let n = values.len();
-    let mut max_val = f32::NEG_INFINITY;
-    unsafe {
+    let mut max_val = unsafe {
         let chunks = n / 4;
         let mut vmax = vdupq_n_f32(f32::NEG_INFINITY);
         for i in 0..chunks { vmax = vmaxq_f32(vmax, vld1q_f32(values.as_ptr().add(i * 4))); }
-        max_val = vmaxvq_f32(vmax);
-    }
+        vmaxvq_f32(vmax)
+    };
     for i in (n / 4 * 4)..n { if values[i] > max_val { max_val = values[i]; } }
     // Exp and sum
     let mut sum = 0.0f32;
@@ -775,15 +775,23 @@ fn emit_forward_function(
     )?;
     writeln!(code)?;
     writeln!(code, "    // Logits projection (parallelized — largest single matmul)")?;
+    writeln!(code, "    // Uses larger chunks (256) to amortize Rayon overhead")?;
     writeln!(code, "    let mut logits = vec![0.0f32; VOCAB_SIZE];")?;
     writeln!(
         code,
-        "    logits.par_iter_mut().enumerate().for_each(|(j, out)| {{"
+        "    logits.par_chunks_mut(256).enumerate().for_each(|(chunk_idx, out)| {{"
+    )?;
+    writeln!(code, "        let base = chunk_idx * 256;")?;
+    writeln!(code, "        for r in 0..out.len() {{")?;
+    writeln!(
+        code,
+        "            let j = base + r;"
     )?;
     writeln!(
         code,
-        "        *out = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
+        "            out[r] = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
     )?;
+    writeln!(code, "        }}")?;
     writeln!(code, "    }});")?;
     writeln!(code)?;
     writeln!(code, "    cache.len += 1;")?;
@@ -963,8 +971,8 @@ mod tests {
 
         // Should have rayon import
         assert!(code.contains("use rayon::prelude::*;"));
-        // Logits should be parallelized
-        assert!(code.contains("par_iter_mut"));
+        // Logits should be parallelized (par_chunks_mut for ILP)
+        assert!(code.contains("par_chunks_mut"));
     }
 
     #[test]

--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -96,7 +96,7 @@ fn generate_main(config: &ModelConfig) -> String {
 mod model;
 
 use std::env;
-use std::io::{{Read, Write}};
+use std::io::Write;
 
 fn load_weights(path: &str) -> Vec<f32> {{
     let file = std::fs::File::open(path).expect("failed to open weights");


### PR DESCRIPTION
## Summary
Final v0.3.0 AOT performance improvements:
1. `par_chunks_mut(256)` for logits — amortizes Rayon overhead
2. Cleaner softmax (returns `max_val` instead of unused initial assignment)
3. `#![allow(dead_code, unused_imports)]` in generated code header
4. Removed unused `use std::io::Read` from generated `main.rs`

## Final v0.3.0 Benchmark Progression (SmolLM2-135M Q8_0, Apple M5 Pro)

| Version | AOT (tok/s) | vs Interpreter |
|---------|-------------|----------------|
| v0.2.0 | 36.2 | 30% |
| v0.3.0-dev1 | 105.2 | 88% |
| v0.3.0-dev2 | 116.2 | 97% |
| **v0.3.0-dev3** | **119.9** | **100%** ✅ |

**3.3x total speedup. AOT now matches the runtime interpreter.**