### PR TITLE
perf: parallel matmul path — par_chunks_mut + ILP (Qwen +34%)

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -1,15 +1,31 @@
 # ForgeLLM Benchmark History
 
-Performance tracking across versions. All benchmarks run on SmolLM2-135M-Instruct Q8_0 (64 tokens, 3 runs).
+Performance tracking across versions. All benchmarks run with 64 tokens, 3 runs.
+System: Darwin arm64 18c (Apple M5 Pro).
 
-## Results
+## SmolLM2-135M Q8_0 (hidden=576, 30 layers)
 
-| Version | Date | Interpreter (tok/s) | AOT (tok/s) | AOT Build (s) | Binary Size | System |
-|---------|------|---------------------|-------------|---------------|-------------|--------|
-| v0.2.0 | 2026-04-09 | 119.7 | 36.2 avg (best: 40.2) | 29s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
-| v0.3.0-dev | 2026-04-09 | 119.7 | **105.2** avg (best: 105.5) | 32s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
-| v0.3.0-dev2 | 2026-04-09 | 119.7 | **116.2** avg (best: 117.8) | 26s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
-| v0.3.0-dev3 | 2026-04-09 | 119.7 | **119.9** avg (best: 122.1) | 26s | 3.8 MB | Darwin arm64 18c (Apple M5 Pro) |
+| Version | Date | Interpreter | AOT | AOT vs Interp |
+|---------|------|------------|-----|---------------|
+| v0.2.0 | 2026-04-09 | 119.7 | 36.2 (best 40.2) | 30% |
+| v0.3.0-dev1 | 2026-04-09 | 119.7 | 105.2 (best 105.5) | 88% |
+| v0.3.0-dev2 | 2026-04-09 | 119.7 | 116.2 (best 117.8) | 97% |
+| v0.3.0-dev3 | 2026-04-09 | 119.7 | 119.9 (best 122.1) | 100% |
+| v0.3.0-dev4 | 2026-04-09 | 119.7 | **119.5** (best 122.9) | **100%** |
+
+## SmolLM2-360M Q8_0 (hidden=960, 32 layers)
+
+| Version | Date | Interpreter | AOT | AOT vs Interp |
+|---------|------|------------|-----|---------------|
+| v0.3.0-dev3 | 2026-04-09 | 46.3 | 44.7 (best 44.9) | 96% |
+| v0.3.0-dev4 | 2026-04-09 | 46.3 | **47.3** (best 47.5) | **102%** |
+
+## Qwen2.5-0.5B Q8_0 (hidden=896, intermediate=4864, vocab=151936)
+
+| Version | Date | Interpreter | AOT | AOT vs Interp |
+|---------|------|------------|-----|---------------|
+| v0.3.0-dev3 | 2026-04-09 | 33.6 | 25.8 (best 26.0) | 77% |
+| v0.3.0-dev4 | 2026-04-09 | 33.6 | **34.5** (best 36.2) | **103%** |
 
 ## Analysis
 
@@ -30,6 +46,19 @@ First release with AOT compilation. Key observations:
 2. **Reduce Rayon overhead** — tune parallelism threshold for small models ✅ DONE (1024 → 4096)
 3. **Optimize logits projection** — largest single matmul (576 x 49152)
 4. **Profile-guided optimization (PGO)** — use cargo-pgo for the AOT binary
+
+### v0.3.0-dev4 — Scaling to Larger Models
+
+After verifying v0.3.0-dev3 on larger models, the parallel matmul path
+(used when N >= 4096) was found to be inefficient — `par_iter_mut`
+single-element granularity caused Rayon overhead to dominate.
+
+Fix: Replaced parallel path with `par_chunks_mut(256)` + 4-way row ILP per thread.
+
+Results across all 3 models:
+- **SmolLM-135M**: 119.5 tok/s (no regression vs dev3)
+- **SmolLM-360M**: 47.3 tok/s (was 44.7, now beats interpreter)
+- **Qwen2.5-0.5B**: 34.5 tok/s (was 25.8, +34%, now beats interpreter)
 
 ### v0.3.0-dev Results
 

--- a/benchmarks/results/0.3.0-dev4-multi-model.json
+++ b/benchmarks/results/0.3.0-dev4-multi-model.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.3.0-dev4",
+  "date": "2026-04-09T23:55:00Z",
+  "system": {
+    "os": "Darwin",
+    "arch": "arm64",
+    "cpu": "Apple M5 Pro",
+    "cores": 18
+  },
+  "models": {
+    "smollm2-135m-q8_0": {
+      "params": "135M",
+      "hidden": 576,
+      "layers": 30,
+      "vocab": 49152,
+      "intermediate": 1536,
+      "interpreter_tok_s": 119.7,
+      "aot_tok_s_avg": 119.5,
+      "aot_tok_s_best": 122.9,
+      "aot_vs_interp_pct": 100
+    },
+    "smollm2-360m-q8_0": {
+      "params": "360M",
+      "hidden": 960,
+      "layers": 32,
+      "vocab": 49152,
+      "interpreter_tok_s": 46.3,
+      "aot_tok_s_avg": 47.3,
+      "aot_tok_s_best": 47.5,
+      "aot_vs_interp_pct": 102
+    },
+    "qwen2.5-0.5b-q8_0": {
+      "params": "494M",
+      "hidden": 896,
+      "layers": 24,
+      "vocab": 151936,
+      "intermediate": 4864,
+      "interpreter_tok_s": 33.6,
+      "aot_tok_s_avg": 34.5,
+      "aot_tok_s_best": 36.2,
+      "aot_vs_interp_pct": 103
+    }
+  },
+  "key_change": "par_chunks_mut(256) + 4-way row ILP for parallel matmul path (was par_iter_mut with single-element granularity)"
+}

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -457,7 +457,8 @@ fn emit_specialized_matmul_functions(
     for &(k, n) in &matmul_shapes(config) {
         writeln!(code, "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]")?;
         if n >= par_threshold {
-            writeln!(code, "/// Parallelized with Rayon ({n} output elements)")?;
+            // Parallel path: par_chunks_mut(256) for cache locality + amortized Rayon overhead
+            writeln!(code, "/// Parallelized: par_chunks_mut(256) with 4-way row ILP per thread")?;
             writeln!(code, "#[inline]")?;
             writeln!(
                 code,
@@ -465,12 +466,23 @@ fn emit_specialized_matmul_functions(
             )?;
             writeln!(
                 code,
-                "    output.par_iter_mut().enumerate().for_each(|(j, out)| {{"
+                "    output.par_chunks_mut(256).enumerate().for_each(|(chunk_idx, out)| {{"
             )?;
-            writeln!(
-                code,
-                "        *out = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
-            )?;
+            writeln!(code, "        let base = chunk_idx * 256;")?;
+            writeln!(code, "        let len = out.len();")?;
+            writeln!(code, "        let chunks4 = len / 4;")?;
+            writeln!(code, "        for c in 0..chunks4 {{")?;
+            writeln!(code, "            let r = c * 4;")?;
+            writeln!(code, "            let j = base + r;")?;
+            writeln!(code, "            out[r]   = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
+            writeln!(code, "            out[r+1] = dot_f32(&input[..], &weight[(j+1)*{k}..(j+2)*{k}], {k});")?;
+            writeln!(code, "            out[r+2] = dot_f32(&input[..], &weight[(j+2)*{k}..(j+3)*{k}], {k});")?;
+            writeln!(code, "            out[r+3] = dot_f32(&input[..], &weight[(j+3)*{k}..(j+4)*{k}], {k});")?;
+            writeln!(code, "        }}")?;
+            writeln!(code, "        for r in (chunks4*4)..len {{")?;
+            writeln!(code, "            let j = base + r;")?;
+            writeln!(code, "            out[r] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
+            writeln!(code, "        }}")?;
             writeln!(code, "    }});")?;
             writeln!(code, "}}")?;
         } else {


### PR DESCRIPTION
## Summary
Fixed the parallel matmul path which was using `par_iter_mut` with
single-element granularity, causing Rayon overhead to dominate for
larger models with `intermediate >= 4096`.

Now uses `par_chunks_mut(256)` + 4-way row ILP per thread.

## Multi-Model Benchmark (Apple M5 Pro 18c)

| Model | Interpreter | AOT (was) | AOT (now) | vs Interp |
|-------|-------------|-----------|-----------|-----------|
| SmolLM-135M | 119.7 | 119.9 | **119.5** | 100% |
| SmolLM-360M |  46.3 |  44.7 |  **47.3** | **102%** |
| Qwen2.5-0.5B |  33.6 |  25.8 |  **34.5** (+34%) | **103%** |

**AOT matches or beats the interpreter on all 3 tested models.**