### PR TITLE
perf: LTO=fat + strip + panic=abort in generated binaries

### DIFF
--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -70,8 +70,10 @@ memmap2 = "0.9"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 codegen-units = 1
+panic = "abort"
+strip = true
 "#
     )
 }


### PR DESCRIPTION
## Summary
Enables more aggressive release profile in generated Cargo.toml:
- `lto = 'fat'` (was 'thin') — full cross-crate inlining
- `strip = true` — removes debug symbols
- `panic = 'abort'` — eliminates unwinding tables

## Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Binary size | 3.8 MB | 2.7 MB | **-29%** |
| Build time | 26s | 32s | +23% |
| SmolLM-135M tok/s | 119.5 | 118.4 | ~same |
| Qwen2.5-0.5B tok/s | 34.5 | 35.8 | **+3.7%** |