### PR TITLE
chore: version bump 0.3.0 — AOT matches interpreter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sauravpanda/forge-llm"
@@ -19,12 +19,12 @@ homepage = "https://forgellm.dev"
 
 [workspace.dependencies]
 # Internal crates
-forgellm-frontend = { version = "0.2.0", path = "crates/forgellm-frontend" }
-forgellm-optimizer = { version = "0.2.0", path = "crates/forgellm-optimizer" }
-forgellm-codegen-cpu = { version = "0.2.0", path = "crates/forgellm-codegen-cpu" }
-forgellm-codegen-wasm = { version = "0.2.0", path = "crates/forgellm-codegen-wasm" }
-forgellm-codegen-gpu = { version = "0.2.0", path = "crates/forgellm-codegen-gpu" }
-forgellm-runtime = { version = "0.2.0", path = "crates/forgellm-runtime" }
+forgellm-frontend = { version = "0.3.0", path = "crates/forgellm-frontend" }
+forgellm-optimizer = { version = "0.3.0", path = "crates/forgellm-optimizer" }
+forgellm-codegen-cpu = { version = "0.3.0", path = "crates/forgellm-codegen-cpu" }
+forgellm-codegen-wasm = { version = "0.3.0", path = "crates/forgellm-codegen-wasm" }
+forgellm-codegen-gpu = { version = "0.3.0", path = "crates/forgellm-codegen-gpu" }
+forgellm-runtime = { version = "0.3.0", path = "crates/forgellm-runtime" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
Bumps all 7 crates from 0.2.0 → 0.3.0.

## v0.3.0 Highlights — AOT Performance Release

**3.3x AOT speedup** vs v0.2.0. AOT binaries now match or exceed the runtime interpreter on all tested models.

| Model | Interpreter | AOT v0.2.0 | AOT v0.3.0 | Speedup |
|-------|-------------|------------|------------|---------|
| SmolLM-135M | 119.7 | 36.2 | **119.5** | **3.3x** |
| SmolLM-360M | 46.3 | — | **47.3** | — |
| Qwen2.5-0.5B | 33.6 | — | **35.8** | — |

Plus: binary size 3.8 MB → 2.7 MB (-29%)