### PR TITLE
docs: v0.3.0 README benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forgellm-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-cpu"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-gpu"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-frontend"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "memmap2",
  "pretty_assertions",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-optimizer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",

--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ Supports 12 GGUF quantization formats: F32, F16, BF16, Q8_0, Q4_0, Q4_1, Q2_K th
 
 ## Performance
 
-Optimized kernels (unrolled matmul) on Apple Silicon:
+v0.3.0 benchmarks on Apple M5 Pro (Q8_0 quantization, 64 tokens):
 
-| Model | Params | Generation |
-|-------|--------|------------|
-| SmolLM2-135M Q8_0 | 135M | **46.3 tok/s** |
-| SmolLM2-360M Q8_0 | 360M | **17.5 tok/s** |
-| Qwen2.5-0.5B Q8_0 | 494M | **12.0 tok/s** |
+| Model | Params | Interpreter | AOT Binary |
+|-------|--------|-------------|------------|
+| SmolLM2-135M | 135M | 119.7 tok/s | **119.5 tok/s** |
+| SmolLM2-360M | 360M | 46.3 tok/s | **47.3 tok/s** |
+| Qwen2.5-0.5B | 494M | 33.6 tok/s | **35.8 tok/s** |
+
+AOT binaries match or exceed interpreter performance with the bonus of
+single-file deployment, smaller memory footprint, and faster startup.
+See [`benchmarks/HISTORY.md`](benchmarks/HISTORY.md) for version-over-version progress.
 
 ## AOT Compilation
 


### PR DESCRIPTION
Updates README with v0.3.0 multi-model benchmark results showing AOT matching/exceeding interpreter on all 3 tested models.