### PR TITLE
fix: chat /clear uses cache.reset() and clears recent_tokens

### DIFF
--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -323,7 +323,8 @@ fn main() {{
             let input = input.trim();
             if input == "/quit" || input == "/exit" {{ break; }}
             if input == "/clear" {{
-                cache = model::KVCache::new();
+                cache.reset();
+                recent_tokens.clear();
                 eprintln!("Cache cleared.");
                 continue;
             }}


### PR DESCRIPTION
Avoids re-allocating KV cache on /clear. Also fixes lingering recent_tokens.