### PR TITLE
fix: resolve CI blockers (fmt + clippy)

### DIFF
--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -214,7 +214,16 @@ fn main() -> Result<()> {
             tokenizer,
             embed_weights,
             cross_target,
-        } => cmd_compile(&model, &target, &output, run, prompt.as_deref(), &tokenizer, embed_weights, cross_target.as_deref())?,
+        } => cmd_compile(CompileArgs {
+            model_path: &model,
+            target: &target,
+            output_path: &output,
+            run,
+            prompt: prompt.as_deref(),
+            tokenizer_opt: &tokenizer,
+            embed_weights,
+            cross_target: cross_target.as_deref(),
+        })?,
 
         Commands::ExportWeights { model, output } => cmd_export_weights(&model, &output)?,
 
@@ -462,16 +471,28 @@ fn resolve_tokenizer(tokenizer: &Option<String>, model_path: &str) -> Result<Str
     )
 }
 
-fn cmd_compile(
-    model_path: &str,
-    target: &str,
-    output_path: &str,
+struct CompileArgs<'a> {
+    model_path: &'a str,
+    target: &'a str,
+    output_path: &'a str,
     run: bool,
-    prompt: Option<&str>,
-    tokenizer_opt: &Option<String>,
+    prompt: Option<&'a str>,
+    tokenizer_opt: &'a Option<String>,
     embed_weights: bool,
-    cross_target: Option<&str>,
-) -> Result<()> {
+    cross_target: Option<&'a str>,
+}
+
+fn cmd_compile(args: CompileArgs<'_>) -> Result<()> {
+    let CompileArgs {
+        model_path,
+        target,
+        output_path,
+        run,
+        prompt,
+        tokenizer_opt,
+        embed_weights,
+        cross_target,
+    } = args;
     println!("Loading model config from {model_path}...");
     let config = load_model_config(model_path)?;
 
@@ -520,8 +541,13 @@ fn cmd_compile(
         .unwrap_or_else(|| "model".to_string());
 
     match target {
-        "cpu" => forgellm_codegen_cpu::generate_project(&optimized, output_dir, &model_name, embed_weights)
-            .map_err(|e| anyhow::anyhow!("project generation failed: {e}"))?,
+        "cpu" => forgellm_codegen_cpu::generate_project(
+            &optimized,
+            output_dir,
+            &model_name,
+            embed_weights,
+        )
+        .map_err(|e| anyhow::anyhow!("project generation failed: {e}"))?,
         _ => bail!("unsupported target: {target} (supported: cpu)"),
     }
 
@@ -575,31 +601,42 @@ fn cmd_compile(
     }
 
     // Build with cargo
-    let target_info = cross_target.map(|t| format!(" --target {t}")).unwrap_or_default();
+    let target_info = cross_target
+        .map(|t| format!(" --target {t}"))
+        .unwrap_or_default();
     println!("[3/4] Building release binary (cargo build --release{target_info})...");
     let mut build_cmd = std::process::Command::new("cargo");
-    build_cmd.arg("build").arg("--release").current_dir(output_dir);
+    build_cmd
+        .arg("build")
+        .arg("--release")
+        .current_dir(output_dir);
     if let Some(ct) = cross_target {
         build_cmd.arg("--target").arg(ct);
     }
-    let build_status = build_cmd.status().with_context(|| "failed to run cargo build")?;
+    let build_status = build_cmd
+        .status()
+        .with_context(|| "failed to run cargo build")?;
 
     if !build_status.success() {
-        bail!("cargo build --release failed with exit code: {}", build_status);
+        bail!(
+            "cargo build --release failed with exit code: {}",
+            build_status
+        );
     }
     println!("  Build complete.");
 
     // Run the binary
     let binary_path = if let Some(ct) = cross_target {
-        output_dir.join("target").join(ct).join("release").join(&model_name)
+        output_dir
+            .join("target")
+            .join(ct)
+            .join("release")
+            .join(&model_name)
     } else {
         output_dir.join("target").join("release").join(&model_name)
     };
     if !binary_path.exists() {
-        bail!(
-            "expected binary not found at {}",
-            binary_path.display()
-        );
+        bail!("expected binary not found at {}", binary_path.display());
     }
 
     let run_prompt = prompt.unwrap_or("Hello, world!");
@@ -609,7 +646,12 @@ fn cmd_compile(
     let mut cmd = std::process::Command::new(&binary_path);
     if !embed_weights {
         cmd.arg(output_dir.join("weights.bin").to_string_lossy().to_string());
-        cmd.arg(output_dir.join("tokenizer.json").to_string_lossy().to_string());
+        cmd.arg(
+            output_dir
+                .join("tokenizer.json")
+                .to_string_lossy()
+                .to_string(),
+        );
     }
     cmd.arg(run_prompt);
 

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -58,7 +58,10 @@ fn emit_header(code: &mut String, config: &ModelConfig) -> Result<(), CodegenErr
     )?;
     writeln!(code)?;
     writeln!(code, "#![allow(clippy::excessive_precision)]")?;
-    writeln!(code, "#![allow(dead_code, unused_imports, unused_assignments)]")?;
+    writeln!(
+        code,
+        "#![allow(dead_code, unused_imports, unused_assignments)]"
+    )?;
     writeln!(code)?;
     writeln!(code, "use rayon::prelude::*;")?;
     writeln!(code)?;
@@ -104,14 +107,20 @@ fn emit_header(code: &mut String, config: &ModelConfig) -> Result<(), CodegenErr
     writeln!(code)?;
 
     // Aligned buffer type for SIMD-friendly memory access
-    writeln!(code, "/// Cache-line aligned buffer for optimal SIMD performance.")?;
+    writeln!(
+        code,
+        "/// Cache-line aligned buffer for optimal SIMD performance."
+    )?;
     writeln!(code, "#[repr(C, align(64))]")?;
     writeln!(code, "pub struct AlignedBuf<const N: usize>(pub [f32; N]);")?;
     writeln!(code)?;
     writeln!(code, "impl<const N: usize> AlignedBuf<N> {{")?;
     writeln!(code, "    pub fn new() -> Self {{ Self([0.0f32; N]) }}")?;
     writeln!(code, "    pub fn as_slice(&self) -> &[f32] {{ &self.0 }}")?;
-    writeln!(code, "    pub fn as_mut_slice(&mut self) -> &mut [f32] {{ &mut self.0 }}")?;
+    writeln!(
+        code,
+        "    pub fn as_mut_slice(&mut self) -> &mut [f32] {{ &mut self.0 }}"
+    )?;
     writeln!(code, "}}")?;
     writeln!(code)?;
 
@@ -451,7 +460,10 @@ fn emit_specialized_matmul_functions(
     config: &ModelConfig,
 ) -> Result<(), CodegenError> {
     writeln!(code, "// --- Shape-specialized matmul functions (m=1) ---")?;
-    writeln!(code, "// All dimensions baked in at compile time — no runtime size parameters.")?;
+    writeln!(
+        code,
+        "// All dimensions baked in at compile time — no runtime size parameters."
+    )?;
     writeln!(code)?;
 
     // Threshold for parallelization: only parallelize if N >= 4096
@@ -459,10 +471,16 @@ fn emit_specialized_matmul_functions(
     let par_threshold = 4096;
 
     for &(k, n) in &matmul_shapes(config) {
-        writeln!(code, "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]")?;
+        writeln!(
+            code,
+            "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]"
+        )?;
         if n >= par_threshold {
             // Parallel path: par_chunks_mut(256) for cache locality + amortized Rayon overhead
-            writeln!(code, "/// Parallelized: par_chunks_mut(256) with 4-way row ILP per thread")?;
+            writeln!(
+                code,
+                "/// Parallelized: par_chunks_mut(256) with 4-way row ILP per thread"
+            )?;
             writeln!(code, "#[inline]")?;
             writeln!(
                 code,
@@ -478,14 +496,29 @@ fn emit_specialized_matmul_functions(
             writeln!(code, "        for c in 0..chunks4 {{")?;
             writeln!(code, "            let r = c * 4;")?;
             writeln!(code, "            let j = base + r;")?;
-            writeln!(code, "            out[r]   = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
-            writeln!(code, "            out[r+1] = dot_f32(&input[..], &weight[(j+1)*{k}..(j+2)*{k}], {k});")?;
-            writeln!(code, "            out[r+2] = dot_f32(&input[..], &weight[(j+2)*{k}..(j+3)*{k}], {k});")?;
-            writeln!(code, "            out[r+3] = dot_f32(&input[..], &weight[(j+3)*{k}..(j+4)*{k}], {k});")?;
+            writeln!(
+                code,
+                "            out[r]   = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+1] = dot_f32(&input[..], &weight[(j+1)*{k}..(j+2)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+2] = dot_f32(&input[..], &weight[(j+2)*{k}..(j+3)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+3] = dot_f32(&input[..], &weight[(j+3)*{k}..(j+4)*{k}], {k});"
+            )?;
             writeln!(code, "        }}")?;
             writeln!(code, "        for r in (chunks4*4)..len {{")?;
             writeln!(code, "            let j = base + r;")?;
-            writeln!(code, "            out[r] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
+            writeln!(
+                code,
+                "            out[r] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
+            )?;
             writeln!(code, "        }}")?;
             writeln!(code, "    }});")?;
             writeln!(code, "}}")?;
@@ -499,10 +532,16 @@ fn emit_specialized_matmul_functions(
             let n_chunks = n / 4;
             let n_remainder = n % 4;
             if n_chunks > 0 {
-                writeln!(code, "    // Process 4 output rows at a time for instruction-level parallelism")?;
+                writeln!(
+                    code,
+                    "    // Process 4 output rows at a time for instruction-level parallelism"
+                )?;
                 writeln!(code, "    for chunk in 0..{n_chunks} {{")?;
                 writeln!(code, "        let j0 = chunk * 4;")?;
-                writeln!(code, "        output[j0]   = dot_f32(&input[..], &weight[j0*{k}..(j0+1)*{k}], {k});")?;
+                writeln!(
+                    code,
+                    "        output[j0]   = dot_f32(&input[..], &weight[j0*{k}..(j0+1)*{k}], {k});"
+                )?;
                 writeln!(code, "        output[j0+1] = dot_f32(&input[..], &weight[(j0+1)*{k}..(j0+2)*{k}], {k});")?;
                 writeln!(code, "        output[j0+2] = dot_f32(&input[..], &weight[(j0+2)*{k}..(j0+3)*{k}], {k});")?;
                 writeln!(code, "        output[j0+3] = dot_f32(&input[..], &weight[(j0+3)*{k}..(j0+4)*{k}], {k});")?;
@@ -594,7 +633,10 @@ fn emit_forward_function(
     writeln!(code)?;
 
     writeln!(code, "/// KV cache for autoregressive generation.")?;
-    writeln!(code, "/// Pre-allocated to MAX_SEQ_LEN — zero allocations during inference.")?;
+    writeln!(
+        code,
+        "/// Pre-allocated to MAX_SEQ_LEN — zero allocations during inference."
+    )?;
     writeln!(code, "pub struct KVCache {{")?;
     writeln!(
         code,
@@ -634,7 +676,10 @@ fn emit_forward_function(
     writeln!(code)?;
     writeln!(code, "    /// Memory used by KV cache in bytes")?;
     writeln!(code, "    pub fn memory_bytes(&self) -> usize {{")?;
-    writeln!(code, "        NUM_LAYERS * MAX_SEQ_LEN * {kv_size} * 4 * 2  // k + v, f32")?;
+    writeln!(
+        code,
+        "        NUM_LAYERS * MAX_SEQ_LEN * {kv_size} * 4 * 2  // k + v, f32"
+    )?;
     writeln!(code, "    }}")?;
     writeln!(code, "}}")?;
     writeln!(code)?;
@@ -657,10 +702,7 @@ fn emit_forward_function(
 
     // Embedding
     writeln!(code, "    // Embedding lookup")?;
-    writeln!(
-        code,
-        "    let mut hidden_state = [0.0f32; HIDDEN_SIZE];"
-    )?;
+    writeln!(code, "    let mut hidden_state = [0.0f32; HIDDEN_SIZE];")?;
     writeln!(
         code,
         "    embedding(&mut hidden_state, token_id, &weights.embed_tokens, HIDDEN_SIZE);"
@@ -668,7 +710,10 @@ fn emit_forward_function(
     writeln!(code)?;
 
     // Buffers — fixed-size arrays, zero heap allocation
-    writeln!(code, "    // Fixed-size buffers — zero heap allocation during forward pass")?;
+    writeln!(
+        code,
+        "    // Fixed-size buffers — zero heap allocation during forward pass"
+    )?;
     writeln!(code, "    let mut normed = [0.0f32; {hidden}];")?;
     writeln!(code, "    let mut q = [0.0f32; {qk_size}];")?;
     writeln!(code, "    let mut k = [0.0f32; {kv_size}];")?;
@@ -680,8 +725,14 @@ fn emit_forward_function(
     writeln!(code, "    let mut ffn_hidden = [0.0f32; {intermediate}];")?;
     writeln!(code, "    let mut ffn_out = [0.0f32; {hidden}];")?;
     writeln!(code)?;
-    writeln!(code, "    // Precomputed RoPE frequencies — avoids powf per token")?;
-    writeln!(code, "    let rope_freqs = rope_freqs(HEAD_DIM, ROPE_THETA);")?;
+    writeln!(
+        code,
+        "    // Precomputed RoPE frequencies — avoids powf per token"
+    )?;
+    writeln!(
+        code,
+        "    let rope_freqs = rope_freqs(HEAD_DIM, ROPE_THETA);"
+    )?;
     writeln!(code)?;
 
     // Transformer layers
@@ -699,17 +750,20 @@ fn emit_forward_function(
     writeln!(
         code,
         "        matmul_vec_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
-        hidden = hidden, qk_size = qk_size
+        hidden = hidden,
+        qk_size = qk_size
     )?;
     writeln!(
         code,
         "        matmul_vec_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
-        hidden = hidden, kv_size = kv_size
+        hidden = hidden,
+        kv_size = kv_size
     )?;
     writeln!(
         code,
         "        matmul_vec_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
-        hidden = hidden, kv_size = kv_size
+        hidden = hidden,
+        kv_size = kv_size
     )?;
     writeln!(code)?;
     writeln!(code, "        // RoPE")?;
@@ -722,7 +776,10 @@ fn emit_forward_function(
         "        rope(&mut k, pos, HEAD_DIM, NUM_KV_HEADS, &rope_freqs);"
     )?;
     writeln!(code)?;
-    writeln!(code, "        // Update KV cache (direct indexed write, no allocation)")?;
+    writeln!(
+        code,
+        "        // Update KV cache (direct indexed write, no allocation)"
+    )?;
     writeln!(
         code,
         "        cache.k[layer_idx][pos*{kv_size}..(pos+1)*{kv_size}].copy_from_slice(&k);",
@@ -752,12 +809,10 @@ fn emit_forward_function(
     writeln!(
         code,
         "        matmul_vec_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
-        qk_size = qk_size, hidden = hidden
+        qk_size = qk_size,
+        hidden = hidden
     )?;
-    writeln!(
-        code,
-        "        residual_add(&mut hidden_state, &attn_proj);"
-    )?;
+    writeln!(code, "        residual_add(&mut hidden_state, &attn_proj);")?;
     writeln!(code)?;
     writeln!(code, "        // FFN norm")?;
     writeln!(
@@ -772,28 +827,25 @@ fn emit_forward_function(
     writeln!(
         code,
         "        matmul_vec_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
-        hidden = hidden, intermediate = intermediate
+        hidden = hidden,
+        intermediate = intermediate
     )?;
     writeln!(
         code,
         "        matmul_vec_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
-        hidden = hidden, intermediate = intermediate
+        hidden = hidden,
+        intermediate = intermediate
     )?;
-    writeln!(
-        code,
-        "        silu_mul(&mut ffn_hidden, &gate, &up);"
-    )?;
+    writeln!(code, "        silu_mul(&mut ffn_hidden, &gate, &up);")?;
     writeln!(
         code,
         "        matmul_vec_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
-        intermediate = intermediate, hidden = hidden
+        intermediate = intermediate,
+        hidden = hidden
     )?;
     writeln!(code)?;
     writeln!(code, "        // Fused residual add")?;
-    writeln!(
-        code,
-        "        residual_add(&mut hidden_state, &ffn_out);"
-    )?;
+    writeln!(code, "        residual_add(&mut hidden_state, &ffn_out);")?;
     writeln!(code, "    }}")?;
     writeln!(code)?;
 
@@ -804,8 +856,14 @@ fn emit_forward_function(
         "    rms_norm(&mut normed, &hidden_state, &weights.final_norm, RMS_NORM_EPS);"
     )?;
     writeln!(code)?;
-    writeln!(code, "    // Logits projection (parallelized — largest single matmul)")?;
-    writeln!(code, "    // Uses larger chunks (256) to amortize Rayon overhead")?;
+    writeln!(
+        code,
+        "    // Logits projection (parallelized — largest single matmul)"
+    )?;
+    writeln!(
+        code,
+        "    // Uses larger chunks (256) to amortize Rayon overhead"
+    )?;
     writeln!(code, "    let mut logits = vec![0.0f32; VOCAB_SIZE];")?;
     writeln!(
         code,
@@ -813,10 +871,7 @@ fn emit_forward_function(
     )?;
     writeln!(code, "        let base = chunk_idx * 256;")?;
     writeln!(code, "        for r in 0..out.len() {{")?;
-    writeln!(
-        code,
-        "            let j = base + r;"
-    )?;
+    writeln!(code, "            let j = base + r;")?;
     writeln!(
         code,
         "            out[r] = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
@@ -939,11 +994,11 @@ mod tests {
         assert!(code.contains("pub const NUM_LAYERS: usize = 30;"));
 
         // Shape-specialized matmul: hidden=576, qk=9*64=576, kv=3*64=192, inter=1536
-        assert!(code.contains("fn matmul_vec_576x576("));  // q_proj (hidden→qk)
-        assert!(code.contains("fn matmul_vec_576x192("));  // k/v_proj (hidden→kv)
+        assert!(code.contains("fn matmul_vec_576x576(")); // q_proj (hidden→qk)
+        assert!(code.contains("fn matmul_vec_576x192(")); // k/v_proj (hidden→kv)
         assert!(code.contains("fn matmul_vec_576x1536(")); // gate/up_proj
         assert!(code.contains("fn matmul_vec_1536x576(")); // down_proj
-        // Forward function uses specialized calls
+                                                           // Forward function uses specialized calls
         assert!(code.contains("matmul_vec_576x576(&mut q"));
         assert!(code.contains("matmul_vec_576x192(&mut k"));
         assert!(!code.contains("matmul(&mut q")); // no generic matmul calls

--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -712,11 +712,22 @@ mod tests {
 
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
         // Find /clear handler and verify it uses cache.reset()
-        let clear_idx = main.find("if input == \"/clear\"").expect("clear handler missing");
-        let after_clear = &main[clear_idx..clear_idx+200];
-        assert!(after_clear.contains("cache.reset()"), "expected cache.reset() in /clear handler");
-        assert!(after_clear.contains("recent_tokens.clear()"), "expected recent_tokens.clear() in /clear handler");
-        assert!(!after_clear.contains("KVCache::new()"), "should not re-allocate cache on /clear");
+        let clear_idx = main
+            .find("if input == \"/clear\"")
+            .expect("clear handler missing");
+        let after_clear = &main[clear_idx..clear_idx + 200];
+        assert!(
+            after_clear.contains("cache.reset()"),
+            "expected cache.reset() in /clear handler"
+        );
+        assert!(
+            after_clear.contains("recent_tokens.clear()"),
+            "expected recent_tokens.clear() in /clear handler"
+        );
+        assert!(
+            !after_clear.contains("KVCache::new()"),
+            "should not re-allocate cache on /clear"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -732,7 +743,10 @@ mod tests {
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
         assert!(main.contains("--seed"), "should support --seed flag");
         assert!(main.contains("let seed = "), "should parse seed");
-        assert!(main.contains("let mut rng_state: u64 = seed;"), "should use parsed seed");
+        assert!(
+            main.contains("let mut rng_state: u64 = seed;"),
+            "should use parsed seed"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -746,8 +760,14 @@ mod tests {
         generate_project(&graph, &dir, "test-ver", false).unwrap();
 
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
-        assert!(main.contains("KV cache:"), "version output should show KV cache size");
-        assert!(main.contains("kv_bytes"), "should compute KV bytes from constants");
+        assert!(
+            main.contains("KV cache:"),
+            "version output should show KV cache size"
+        );
+        assert!(
+            main.contains("kv_bytes"),
+            "should compute KV bytes from constants"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary
- Refactor `cmd_compile` to accept `CompileArgs` struct, fixing `clippy::too_many_arguments` (8 params exceeded the 7 limit) which fails CI under `-D warnings`
- Apply `cargo fmt` to `main.rs`, `emit.rs`, and `project.rs` to fix formatting check failures

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)