### PR TITLE
perf: quantized matmul without dequantization for Q8_0 (#54)

### DIFF
--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -214,7 +214,16 @@ fn main() -> Result<()> {
             tokenizer,
             embed_weights,
             cross_target,
-        } => cmd_compile(&model, &target, &output, run, prompt.as_deref(), &tokenizer, embed_weights, cross_target.as_deref())?,
+        } => cmd_compile(
+            &model,
+            &target,
+            &output,
+            run,
+            prompt.as_deref(),
+            &tokenizer,
+            embed_weights,
+            cross_target.as_deref(),
+        )?,
 
         Commands::ExportWeights { model, output } => cmd_export_weights(&model, &output)?,
 
@@ -462,6 +471,7 @@ fn resolve_tokenizer(tokenizer: &Option<String>, model_path: &str) -> Result<Str
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_compile(
     model_path: &str,
     target: &str,
@@ -520,8 +530,13 @@ fn cmd_compile(
         .unwrap_or_else(|| "model".to_string());
 
     match target {
-        "cpu" => forgellm_codegen_cpu::generate_project(&optimized, output_dir, &model_name, embed_weights)
-            .map_err(|e| anyhow::anyhow!("project generation failed: {e}"))?,
+        "cpu" => forgellm_codegen_cpu::generate_project(
+            &optimized,
+            output_dir,
+            &model_name,
+            embed_weights,
+        )
+        .map_err(|e| anyhow::anyhow!("project generation failed: {e}"))?,
         _ => bail!("unsupported target: {target} (supported: cpu)"),
     }
 
@@ -575,31 +590,42 @@ fn cmd_compile(
     }
 
     // Build with cargo
-    let target_info = cross_target.map(|t| format!(" --target {t}")).unwrap_or_default();
+    let target_info = cross_target
+        .map(|t| format!(" --target {t}"))
+        .unwrap_or_default();
     println!("[3/4] Building release binary (cargo build --release{target_info})...");
     let mut build_cmd = std::process::Command::new("cargo");
-    build_cmd.arg("build").arg("--release").current_dir(output_dir);
+    build_cmd
+        .arg("build")
+        .arg("--release")
+        .current_dir(output_dir);
     if let Some(ct) = cross_target {
         build_cmd.arg("--target").arg(ct);
     }
-    let build_status = build_cmd.status().with_context(|| "failed to run cargo build")?;
+    let build_status = build_cmd
+        .status()
+        .with_context(|| "failed to run cargo build")?;
 
     if !build_status.success() {
-        bail!("cargo build --release failed with exit code: {}", build_status);
+        bail!(
+            "cargo build --release failed with exit code: {}",
+            build_status
+        );
     }
     println!("  Build complete.");
 
     // Run the binary
     let binary_path = if let Some(ct) = cross_target {
-        output_dir.join("target").join(ct).join("release").join(&model_name)
+        output_dir
+            .join("target")
+            .join(ct)
+            .join("release")
+            .join(&model_name)
     } else {
         output_dir.join("target").join("release").join(&model_name)
     };
     if !binary_path.exists() {
-        bail!(
-            "expected binary not found at {}",
-            binary_path.display()
-        );
+        bail!("expected binary not found at {}", binary_path.display());
     }
 
     let run_prompt = prompt.unwrap_or("Hello, world!");
@@ -609,7 +635,12 @@ fn cmd_compile(
     let mut cmd = std::process::Command::new(&binary_path);
     if !embed_weights {
         cmd.arg(output_dir.join("weights.bin").to_string_lossy().to_string());
-        cmd.arg(output_dir.join("tokenizer.json").to_string_lossy().to_string());
+        cmd.arg(
+            output_dir
+                .join("tokenizer.json")
+                .to_string_lossy()
+                .to_string(),
+        );
     }
     cmd.arg(run_prompt);
 
@@ -1530,103 +1561,197 @@ fn cmd_models(dir: &str) -> Result<()> {
 }
 
 fn cmd_export_weights(model_path: &str, output_path: &str) -> Result<()> {
+    use forgellm_frontend::ir::DType;
+    use forgellm_frontend::weight_loader::{load_from_file_mixed, WeightData};
+
     eprintln!("Loading model from {model_path}...");
     let config = load_model_config(model_path)?;
-    let (_gguf_file, weights) =
-        weight_loader::load_from_file(model_path).with_context(|| "failed to load weights")?;
 
-    eprintln!(
-        "Model: {} | {} layers | {} tensors | {:.1} MB",
-        config.architecture,
-        config.num_layers,
-        weights.len(),
-        weights.memory_bytes() as f64 / 1e6,
-    );
+    let is_q8 = config.dtype == DType::Q8_0;
 
-    // Write weights in a deterministic order matching the AOT binary's expected layout:
-    // embed_tokens, then per-layer weights, then final_norm, then lm_head
-    let mut output_data: Vec<u8> = Vec::with_capacity(weights.memory_bytes());
+    if is_q8 {
+        // Q8_0: keep projection weights as raw bytes, dequantize norm/embed to f32
+        let (_gguf_file, weights) =
+            load_from_file_mixed(model_path).with_context(|| "failed to load weights")?;
 
-    let write_tensor = |data: &mut Vec<u8>, name: &str, weights: &weight_loader::ModelWeights| {
-        let tensor = weights.get(name).unwrap_or_else(|| {
-            // For lm_head, fall back to embed_tokens (tied weights)
-            if name == "lm_head.weight" {
-                weights
-                    .get("model.embed_tokens.weight")
-                    .expect("neither lm_head nor embed_tokens found")
-            } else {
-                panic!("weight not found: {name}")
+        eprintln!(
+            "Model: {} | {} layers | {} tensors | {:.1} MB (Q8_0 raw)",
+            config.architecture,
+            config.num_layers,
+            weights.len(),
+            weights.memory_bytes() as f64 / 1e6,
+        );
+
+        let mut output_data: Vec<u8> = Vec::with_capacity(weights.memory_bytes());
+
+        // Write a tensor — for Q8_0 models: f32 tensors as f32 bytes, Q8_0 as raw bytes
+        let write_mixed = |data: &mut Vec<u8>, name: &str| {
+            match weights.get(name) {
+                Some(WeightData::F32(v)) => {
+                    for &val in v {
+                        data.extend_from_slice(&val.to_le_bytes());
+                    }
+                }
+                Some(WeightData::Q8_0Raw(b)) => {
+                    data.extend_from_slice(b);
+                }
+                None => {
+                    // lm_head fallback: use embed_tokens
+                    if name == "lm_head.weight" {
+                        match weights.get("model.embed_tokens.weight") {
+                            Some(WeightData::F32(v)) => {
+                                for &val in v {
+                                    data.extend_from_slice(&val.to_le_bytes());
+                                }
+                            }
+                            Some(WeightData::Q8_0Raw(b)) => {
+                                data.extend_from_slice(b);
+                            }
+                            None => panic!("neither lm_head nor embed_tokens found"),
+                        }
+                    } else {
+                        panic!("weight not found: {name}");
+                    }
+                }
             }
-        });
-        for &val in tensor {
-            data.extend_from_slice(&val.to_le_bytes());
+        };
+
+        write_mixed(&mut output_data, "model.embed_tokens.weight");
+
+        for layer_idx in 0..config.num_layers {
+            let prefix = format!("model.layers.{layer_idx}");
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.input_layernorm.weight"),
+            );
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.self_attn.q_proj.weight"),
+            );
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.self_attn.k_proj.weight"),
+            );
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.self_attn.v_proj.weight"),
+            );
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.self_attn.o_proj.weight"),
+            );
+            write_mixed(
+                &mut output_data,
+                &format!("{prefix}.post_attention_layernorm.weight"),
+            );
+            write_mixed(&mut output_data, &format!("{prefix}.mlp.gate_proj.weight"));
+            write_mixed(&mut output_data, &format!("{prefix}.mlp.up_proj.weight"));
+            write_mixed(&mut output_data, &format!("{prefix}.mlp.down_proj.weight"));
         }
-    };
 
-    // Embedding
-    write_tensor(&mut output_data, "model.embed_tokens.weight", &weights);
+        write_mixed(&mut output_data, "model.norm.weight");
+        write_mixed(&mut output_data, "lm_head.weight");
 
-    // Per-layer weights
-    for layer_idx in 0..config.num_layers {
-        let prefix = format!("model.layers.{layer_idx}");
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.input_layernorm.weight"),
-            &weights,
+        fs::write(output_path, &output_data)
+            .with_context(|| format!("failed to write {output_path}"))?;
+
+        eprintln!(
+            "Exported {:.1} MB to {output_path} (Q8_0 raw bytes)",
+            output_data.len() as f64 / 1e6,
         );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.self_attn.q_proj.weight"),
-            &weights,
+    } else {
+        // Non-Q8_0: dequantize everything to f32
+        let (_gguf_file, weights) =
+            weight_loader::load_from_file(model_path).with_context(|| "failed to load weights")?;
+
+        eprintln!(
+            "Model: {} | {} layers | {} tensors | {:.1} MB",
+            config.architecture,
+            config.num_layers,
+            weights.len(),
+            weights.memory_bytes() as f64 / 1e6,
         );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.self_attn.k_proj.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.self_attn.v_proj.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.self_attn.o_proj.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.post_attention_layernorm.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.mlp.gate_proj.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.mlp.up_proj.weight"),
-            &weights,
-        );
-        write_tensor(
-            &mut output_data,
-            &format!("{prefix}.mlp.down_proj.weight"),
-            &weights,
+
+        let mut output_data: Vec<u8> = Vec::with_capacity(weights.memory_bytes());
+
+        let write_tensor =
+            |data: &mut Vec<u8>, name: &str, weights: &weight_loader::ModelWeights| {
+                let tensor = weights.get(name).unwrap_or_else(|| {
+                    if name == "lm_head.weight" {
+                        weights
+                            .get("model.embed_tokens.weight")
+                            .expect("neither lm_head nor embed_tokens found")
+                    } else {
+                        panic!("weight not found: {name}")
+                    }
+                });
+                for &val in tensor {
+                    data.extend_from_slice(&val.to_le_bytes());
+                }
+            };
+
+        write_tensor(&mut output_data, "model.embed_tokens.weight", &weights);
+
+        for layer_idx in 0..config.num_layers {
+            let prefix = format!("model.layers.{layer_idx}");
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.input_layernorm.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.self_attn.q_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.self_attn.k_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.self_attn.v_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.self_attn.o_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.post_attention_layernorm.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.mlp.gate_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.mlp.up_proj.weight"),
+                &weights,
+            );
+            write_tensor(
+                &mut output_data,
+                &format!("{prefix}.mlp.down_proj.weight"),
+                &weights,
+            );
+        }
+
+        write_tensor(&mut output_data, "model.norm.weight", &weights);
+        write_tensor(&mut output_data, "lm_head.weight", &weights);
+
+        fs::write(output_path, &output_data)
+            .with_context(|| format!("failed to write {output_path}"))?;
+
+        eprintln!(
+            "Exported {:.1} MB to {output_path}",
+            output_data.len() as f64 / 1e6,
         );
     }
-
-    // Final norm + lm_head
-    write_tensor(&mut output_data, "model.norm.weight", &weights);
-    write_tensor(&mut output_data, "lm_head.weight", &weights);
-
-    fs::write(output_path, &output_data)
-        .with_context(|| format!("failed to write {output_path}"))?;
-
-    eprintln!(
-        "Exported {:.1} MB to {output_path}",
-        output_data.len() as f64 / 1e6,
-    );
 
     Ok(())
 }

--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -214,16 +214,16 @@ fn main() -> Result<()> {
             tokenizer,
             embed_weights,
             cross_target,
-        } => cmd_compile(
-            &model,
-            &target,
-            &output,
+        } => cmd_compile(CompileArgs {
+            model_path: &model,
+            target: &target,
+            output_path: &output,
             run,
-            prompt.as_deref(),
-            &tokenizer,
+            prompt: prompt.as_deref(),
+            tokenizer_opt: &tokenizer,
             embed_weights,
-            cross_target.as_deref(),
-        )?,
+            cross_target: cross_target.as_deref(),
+        })?,
 
         Commands::ExportWeights { model, output } => cmd_export_weights(&model, &output)?,
 
@@ -471,11 +471,10 @@ fn resolve_tokenizer(tokenizer: &Option<String>, model_path: &str) -> Result<Str
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn cmd_compile(
-    model_path: &str,
-    target: &str,
-    output_path: &str,
+struct CompileArgs<'a> {
+    model_path: &'a str,
+    target: &'a str,
+    output_path: &'a str,
     run: bool,
     prompt: Option<&'a str>,
     tokenizer_opt: &'a Option<String>,

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -25,6 +25,10 @@ pub fn generate(graph: &Graph) -> Result<String, CodegenError> {
 
     emit_header(&mut code, config)?;
     emit_kernel_functions(&mut code)?;
+    if config.dtype == DType::Q8_0 {
+        emit_q8_0_kernel(&mut code)?;
+        emit_specialized_q8_matmul_functions(&mut code, config)?;
+    }
     emit_specialized_matmul_functions(&mut code, config)?;
     emit_forward_function(&mut code, graph, config)?;
 
@@ -58,7 +62,10 @@ fn emit_header(code: &mut String, config: &ModelConfig) -> Result<(), CodegenErr
     )?;
     writeln!(code)?;
     writeln!(code, "#![allow(clippy::excessive_precision)]")?;
-    writeln!(code, "#![allow(dead_code, unused_imports, unused_assignments)]")?;
+    writeln!(
+        code,
+        "#![allow(dead_code, unused_imports, unused_assignments)]"
+    )?;
     writeln!(code)?;
     writeln!(code, "use rayon::prelude::*;")?;
     writeln!(code)?;
@@ -104,14 +111,20 @@ fn emit_header(code: &mut String, config: &ModelConfig) -> Result<(), CodegenErr
     writeln!(code)?;
 
     // Aligned buffer type for SIMD-friendly memory access
-    writeln!(code, "/// Cache-line aligned buffer for optimal SIMD performance.")?;
+    writeln!(
+        code,
+        "/// Cache-line aligned buffer for optimal SIMD performance."
+    )?;
     writeln!(code, "#[repr(C, align(64))]")?;
     writeln!(code, "pub struct AlignedBuf<const N: usize>(pub [f32; N]);")?;
     writeln!(code)?;
     writeln!(code, "impl<const N: usize> AlignedBuf<N> {{")?;
     writeln!(code, "    pub fn new() -> Self {{ Self([0.0f32; N]) }}")?;
     writeln!(code, "    pub fn as_slice(&self) -> &[f32] {{ &self.0 }}")?;
-    writeln!(code, "    pub fn as_mut_slice(&mut self) -> &mut [f32] {{ &mut self.0 }}")?;
+    writeln!(
+        code,
+        "    pub fn as_mut_slice(&mut self) -> &mut [f32] {{ &mut self.0 }}"
+    )?;
     writeln!(code, "}}")?;
     writeln!(code)?;
 
@@ -451,7 +464,10 @@ fn emit_specialized_matmul_functions(
     config: &ModelConfig,
 ) -> Result<(), CodegenError> {
     writeln!(code, "// --- Shape-specialized matmul functions (m=1) ---")?;
-    writeln!(code, "// All dimensions baked in at compile time — no runtime size parameters.")?;
+    writeln!(
+        code,
+        "// All dimensions baked in at compile time — no runtime size parameters."
+    )?;
     writeln!(code)?;
 
     // Threshold for parallelization: only parallelize if N >= 4096
@@ -459,10 +475,16 @@ fn emit_specialized_matmul_functions(
     let par_threshold = 4096;
 
     for &(k, n) in &matmul_shapes(config) {
-        writeln!(code, "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]")?;
+        writeln!(
+            code,
+            "/// Specialized matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}]"
+        )?;
         if n >= par_threshold {
             // Parallel path: par_chunks_mut(256) for cache locality + amortized Rayon overhead
-            writeln!(code, "/// Parallelized: par_chunks_mut(256) with 4-way row ILP per thread")?;
+            writeln!(
+                code,
+                "/// Parallelized: par_chunks_mut(256) with 4-way row ILP per thread"
+            )?;
             writeln!(code, "#[inline]")?;
             writeln!(
                 code,
@@ -478,14 +500,29 @@ fn emit_specialized_matmul_functions(
             writeln!(code, "        for c in 0..chunks4 {{")?;
             writeln!(code, "            let r = c * 4;")?;
             writeln!(code, "            let j = base + r;")?;
-            writeln!(code, "            out[r]   = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
-            writeln!(code, "            out[r+1] = dot_f32(&input[..], &weight[(j+1)*{k}..(j+2)*{k}], {k});")?;
-            writeln!(code, "            out[r+2] = dot_f32(&input[..], &weight[(j+2)*{k}..(j+3)*{k}], {k});")?;
-            writeln!(code, "            out[r+3] = dot_f32(&input[..], &weight[(j+3)*{k}..(j+4)*{k}], {k});")?;
+            writeln!(
+                code,
+                "            out[r]   = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+1] = dot_f32(&input[..], &weight[(j+1)*{k}..(j+2)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+2] = dot_f32(&input[..], &weight[(j+2)*{k}..(j+3)*{k}], {k});"
+            )?;
+            writeln!(
+                code,
+                "            out[r+3] = dot_f32(&input[..], &weight[(j+3)*{k}..(j+4)*{k}], {k});"
+            )?;
             writeln!(code, "        }}")?;
             writeln!(code, "        for r in (chunks4*4)..len {{")?;
             writeln!(code, "            let j = base + r;")?;
-            writeln!(code, "            out[r] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});")?;
+            writeln!(
+                code,
+                "            out[r] = dot_f32(&input[..], &weight[j*{k}..(j+1)*{k}], {k});"
+            )?;
             writeln!(code, "        }}")?;
             writeln!(code, "    }});")?;
             writeln!(code, "}}")?;
@@ -499,10 +536,16 @@ fn emit_specialized_matmul_functions(
             let n_chunks = n / 4;
             let n_remainder = n % 4;
             if n_chunks > 0 {
-                writeln!(code, "    // Process 4 output rows at a time for instruction-level parallelism")?;
+                writeln!(
+                    code,
+                    "    // Process 4 output rows at a time for instruction-level parallelism"
+                )?;
                 writeln!(code, "    for chunk in 0..{n_chunks} {{")?;
                 writeln!(code, "        let j0 = chunk * 4;")?;
-                writeln!(code, "        output[j0]   = dot_f32(&input[..], &weight[j0*{k}..(j0+1)*{k}], {k});")?;
+                writeln!(
+                    code,
+                    "        output[j0]   = dot_f32(&input[..], &weight[j0*{k}..(j0+1)*{k}], {k});"
+                )?;
                 writeln!(code, "        output[j0+1] = dot_f32(&input[..], &weight[(j0+1)*{k}..(j0+2)*{k}], {k});")?;
                 writeln!(code, "        output[j0+2] = dot_f32(&input[..], &weight[(j0+2)*{k}..(j0+3)*{k}], {k});")?;
                 writeln!(code, "        output[j0+3] = dot_f32(&input[..], &weight[(j0+3)*{k}..(j0+4)*{k}], {k});")?;
@@ -513,6 +556,154 @@ fn emit_specialized_matmul_functions(
                 writeln!(code, "    let base = {} * 4;", n_chunks)?;
                 for r in 0..n_remainder {
                     writeln!(code, "    output[base+{r}] = dot_f32(&input[..], &weight[(base+{r})*{k}..(base+{r}+1)*{k}], {k});")?;
+                }
+            }
+            writeln!(code, "}}")?;
+        }
+        writeln!(code)?;
+    }
+
+    Ok(())
+}
+
+/// Emit the Q8_0 dot-product helper and f16→f32 conversion used by Q8_0 matmul.
+fn emit_q8_0_kernel(code: &mut String) -> Result<(), CodegenError> {
+    code.push_str(
+        r#"
+// --- Q8_0 quantized dot product (no dequantization at load time) ---
+/// Convert IEEE 754 half-precision (f16) bit pattern to f32.
+#[inline]
+fn f16_bits_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exponent = ((bits >> 10) & 0x1F) as u32;
+    let mantissa = (bits & 0x3FF) as u32;
+    if exponent == 0 {
+        if mantissa == 0 { return f32::from_bits(sign << 31); }
+        let mut m = mantissa;
+        let mut e: i32 = -14;
+        while m & 0x400 == 0 { m <<= 1; e -= 1; }
+        m &= 0x3FF;
+        let f32_exp = ((e + 127) as u32) & 0xFF;
+        return f32::from_bits((sign << 31) | (f32_exp << 23) | (m << 13));
+    }
+    if exponent == 31 {
+        return f32::from_bits((sign << 31) | (0xFF << 23) | (mantissa << 13));
+    }
+    let f32_exp = (exponent as i32 - 15 + 127) as u32;
+    f32::from_bits((sign << 31) | (f32_exp << 23) | (mantissa << 13))
+}
+
+/// Dot product of f32 input against a Q8_0 weight row without prior dequantization.
+/// `weight_row`: raw Q8_0 bytes — layout: [2 bytes f16 scale][32 bytes int8] per block.
+/// `k`: number of input/weight elements.
+#[inline]
+fn dot_q8_0(input: &[f32], weight_row: &[u8], k: usize) -> f32 {
+    const BLOCK_SIZE: usize = 32;
+    const TYPE_SIZE: usize = 34; // 2 scale bytes + 32 data bytes
+    let num_blocks = k.div_ceil(BLOCK_SIZE);
+    let mut sum = 0.0f32;
+    for b in 0..num_blocks {
+        let bs = b * TYPE_SIZE;
+        let scale_bits = u16::from_le_bytes([weight_row[bs], weight_row[bs + 1]]);
+        let scale = f16_bits_to_f32(scale_bits);
+        let block_start = b * BLOCK_SIZE;
+        let block_end = (block_start + BLOCK_SIZE).min(k);
+        for j in 0..(block_end - block_start) {
+            let q = weight_row[bs + 2 + j] as i8;
+            sum += input[block_start + j] * (q as f32 * scale);
+        }
+    }
+    sum
+}
+
+"#,
+    );
+    Ok(())
+}
+
+/// Collect all unique (k, n) matmul shapes needed for Q8_0 projection weights.
+/// Same shapes as the f32 version but used for Q8_0 `matmul_vec_q8_0_KxN` variants.
+fn q8_matmul_shapes(config: &ModelConfig) -> Vec<(usize, usize)> {
+    matmul_shapes(config)
+}
+
+/// Emit shape-specialized Q8_0 matmul functions: `matmul_vec_q8_0_KxN`.
+/// These take `weight: &[u8]` (raw Q8_0 bytes) and call `dot_q8_0()` per output row.
+fn emit_specialized_q8_matmul_functions(
+    code: &mut String,
+    config: &ModelConfig,
+) -> Result<(), CodegenError> {
+    writeln!(
+        code,
+        "// --- Shape-specialized Q8_0 matmul functions (m=1, weight is &[u8]) ---"
+    )?;
+    writeln!(code)?;
+
+    let par_threshold = 4096;
+
+    for &(k, n) in &q8_matmul_shapes(config) {
+        // Byte size per row: ceil(k/32)*34
+        let row_bytes = k.div_ceil(32) * 34;
+        writeln!(
+            code,
+            "/// Q8_0 matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}] (weight stored as raw Q8_0 bytes)"
+        )?;
+        if n >= par_threshold {
+            writeln!(code, "#[inline]")?;
+            writeln!(
+                code,
+                "fn matmul_vec_q8_0_{k}x{n}(output: &mut [f32; {n}], input: &[f32; {k}], weight: &[u8]) {{"
+            )?;
+            writeln!(
+                code,
+                "    output.par_chunks_mut(256).enumerate().for_each(|(chunk_idx, out)| {{"
+            )?;
+            writeln!(code, "        let base = chunk_idx * 256;")?;
+            writeln!(code, "        for r in 0..out.len() {{")?;
+            writeln!(code, "            let j = base + r;")?;
+            writeln!(
+                code,
+                "            out[r] = dot_q8_0(&input[..], &weight[j*{row_bytes}..(j+1)*{row_bytes}], {k});"
+            )?;
+            writeln!(code, "        }}")?;
+            writeln!(code, "    }});")?;
+            writeln!(code, "}}")?;
+        } else {
+            writeln!(code, "#[inline]")?;
+            writeln!(
+                code,
+                "fn matmul_vec_q8_0_{k}x{n}(output: &mut [f32; {n}], input: &[f32; {k}], weight: &[u8]) {{"
+            )?;
+            let n_chunks = n / 4;
+            let n_remainder = n % 4;
+            if n_chunks > 0 {
+                writeln!(code, "    for chunk in 0..{n_chunks} {{")?;
+                writeln!(code, "        let j0 = chunk * 4;")?;
+                writeln!(
+                    code,
+                    "        output[j0]   = dot_q8_0(&input[..], &weight[j0*{row_bytes}..(j0+1)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+1] = dot_q8_0(&input[..], &weight[(j0+1)*{row_bytes}..(j0+2)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+2] = dot_q8_0(&input[..], &weight[(j0+2)*{row_bytes}..(j0+3)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+3] = dot_q8_0(&input[..], &weight[(j0+3)*{row_bytes}..(j0+4)*{row_bytes}], {k});"
+                )?;
+                writeln!(code, "    }}")?;
+            }
+            if n_remainder > 0 {
+                writeln!(code, "    let base = {n_chunks} * 4;")?;
+                for r in 0..n_remainder {
+                    writeln!(
+                        code,
+                        "    output[base+{r}] = dot_q8_0(&input[..], &weight[(base+{r})*{row_bytes}..(base+{r}+1)*{row_bytes}], {k});"
+                    )?;
                 }
             }
             writeln!(code, "}}")?;
@@ -537,6 +728,11 @@ fn emit_forward_function(
     let qk_size = num_heads * head_dim;
     let kv_size = num_kv_heads * head_dim;
 
+    let is_q8 = config.dtype == DType::Q8_0;
+    // Projection weight type: raw Q8_0 bytes for Q8_0 models, f32 otherwise
+    let proj_type = if is_q8 { "Vec<u8>" } else { "Vec<f32>" };
+    let lm_head_type = if is_q8 { "Vec<u8>" } else { "Vec<f32>" };
+
     writeln!(
         code,
         "/// Model weights — loaded once, passed to forward()."
@@ -550,7 +746,7 @@ fn emit_forward_function(
     writeln!(code, "    pub final_norm: Vec<f32>,          // [{hidden}]")?;
     writeln!(
         code,
-        "    pub lm_head: Vec<f32>,             // [{vocab} * {hidden}]"
+        "    pub lm_head: {lm_head_type},             // [{vocab} * {hidden}]"
     )?;
     writeln!(code, "}}")?;
     writeln!(code)?;
@@ -559,42 +755,45 @@ fn emit_forward_function(
     writeln!(code, "    pub attn_norm: Vec<f32>,           // [{hidden}]")?;
     writeln!(
         code,
-        "    pub q_proj: Vec<f32>,              // [{} * {hidden}]",
+        "    pub q_proj: {proj_type},              // [{} * {hidden}]",
         num_heads * head_dim
     )?;
     writeln!(
         code,
-        "    pub k_proj: Vec<f32>,              // [{} * {hidden}]",
+        "    pub k_proj: {proj_type},              // [{} * {hidden}]",
         num_kv_heads * head_dim
     )?;
     writeln!(
         code,
-        "    pub v_proj: Vec<f32>,              // [{} * {hidden}]",
+        "    pub v_proj: {proj_type},              // [{} * {hidden}]",
         num_kv_heads * head_dim
     )?;
     writeln!(
         code,
-        "    pub o_proj: Vec<f32>,              // [{hidden} * {}]",
+        "    pub o_proj: {proj_type},              // [{hidden} * {}]",
         num_heads * head_dim
     )?;
     writeln!(code, "    pub ffn_norm: Vec<f32>,            // [{hidden}]")?;
     writeln!(
         code,
-        "    pub gate_proj: Vec<f32>,           // [{intermediate} * {hidden}]"
+        "    pub gate_proj: {proj_type},           // [{intermediate} * {hidden}]"
     )?;
     writeln!(
         code,
-        "    pub up_proj: Vec<f32>,             // [{intermediate} * {hidden}]"
+        "    pub up_proj: {proj_type},             // [{intermediate} * {hidden}]"
     )?;
     writeln!(
         code,
-        "    pub down_proj: Vec<f32>,           // [{hidden} * {intermediate}]"
+        "    pub down_proj: {proj_type},           // [{hidden} * {intermediate}]"
     )?;
     writeln!(code, "}}")?;
     writeln!(code)?;
 
     writeln!(code, "/// KV cache for autoregressive generation.")?;
-    writeln!(code, "/// Pre-allocated to MAX_SEQ_LEN — zero allocations during inference.")?;
+    writeln!(
+        code,
+        "/// Pre-allocated to MAX_SEQ_LEN — zero allocations during inference."
+    )?;
     writeln!(code, "pub struct KVCache {{")?;
     writeln!(
         code,
@@ -634,7 +833,10 @@ fn emit_forward_function(
     writeln!(code)?;
     writeln!(code, "    /// Memory used by KV cache in bytes")?;
     writeln!(code, "    pub fn memory_bytes(&self) -> usize {{")?;
-    writeln!(code, "        NUM_LAYERS * MAX_SEQ_LEN * {kv_size} * 4 * 2  // k + v, f32")?;
+    writeln!(
+        code,
+        "        NUM_LAYERS * MAX_SEQ_LEN * {kv_size} * 4 * 2  // k + v, f32"
+    )?;
     writeln!(code, "    }}")?;
     writeln!(code, "}}")?;
     writeln!(code)?;
@@ -657,10 +859,7 @@ fn emit_forward_function(
 
     // Embedding
     writeln!(code, "    // Embedding lookup")?;
-    writeln!(
-        code,
-        "    let mut hidden_state = [0.0f32; HIDDEN_SIZE];"
-    )?;
+    writeln!(code, "    let mut hidden_state = [0.0f32; HIDDEN_SIZE];")?;
     writeln!(
         code,
         "    embedding(&mut hidden_state, token_id, &weights.embed_tokens, HIDDEN_SIZE);"
@@ -668,7 +867,10 @@ fn emit_forward_function(
     writeln!(code)?;
 
     // Buffers — fixed-size arrays, zero heap allocation
-    writeln!(code, "    // Fixed-size buffers — zero heap allocation during forward pass")?;
+    writeln!(
+        code,
+        "    // Fixed-size buffers — zero heap allocation during forward pass"
+    )?;
     writeln!(code, "    let mut normed = [0.0f32; {hidden}];")?;
     writeln!(code, "    let mut q = [0.0f32; {qk_size}];")?;
     writeln!(code, "    let mut k = [0.0f32; {kv_size}];")?;
@@ -680,8 +882,14 @@ fn emit_forward_function(
     writeln!(code, "    let mut ffn_hidden = [0.0f32; {intermediate}];")?;
     writeln!(code, "    let mut ffn_out = [0.0f32; {hidden}];")?;
     writeln!(code)?;
-    writeln!(code, "    // Precomputed RoPE frequencies — avoids powf per token")?;
-    writeln!(code, "    let rope_freqs = rope_freqs(HEAD_DIM, ROPE_THETA);")?;
+    writeln!(
+        code,
+        "    // Precomputed RoPE frequencies — avoids powf per token"
+    )?;
+    writeln!(
+        code,
+        "    let rope_freqs = rope_freqs(HEAD_DIM, ROPE_THETA);"
+    )?;
     writeln!(code)?;
 
     // Transformer layers
@@ -696,21 +904,45 @@ fn emit_forward_function(
     )?;
     writeln!(code)?;
     writeln!(code, "        // QKV projections (shape-specialized)")?;
-    writeln!(
-        code,
-        "        matmul_vec_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
-        hidden = hidden, qk_size = qk_size
-    )?;
-    writeln!(
-        code,
-        "        matmul_vec_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
-        hidden = hidden, kv_size = kv_size
-    )?;
-    writeln!(
-        code,
-        "        matmul_vec_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
-        hidden = hidden, kv_size = kv_size
-    )?;
+    if is_q8 {
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+    } else {
+        writeln!(
+            code,
+            "        matmul_vec_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+    }
     writeln!(code)?;
     writeln!(code, "        // RoPE")?;
     writeln!(
@@ -722,7 +954,10 @@ fn emit_forward_function(
         "        rope(&mut k, pos, HEAD_DIM, NUM_KV_HEADS, &rope_freqs);"
     )?;
     writeln!(code)?;
-    writeln!(code, "        // Update KV cache (direct indexed write, no allocation)")?;
+    writeln!(
+        code,
+        "        // Update KV cache (direct indexed write, no allocation)"
+    )?;
     writeln!(
         code,
         "        cache.k[layer_idx][pos*{kv_size}..(pos+1)*{kv_size}].copy_from_slice(&k);",
@@ -749,15 +984,22 @@ fn emit_forward_function(
     writeln!(code, "        );")?;
     writeln!(code)?;
     writeln!(code, "        // Output projection + fused residual add")?;
-    writeln!(
-        code,
-        "        matmul_vec_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
-        qk_size = qk_size, hidden = hidden
-    )?;
-    writeln!(
-        code,
-        "        residual_add(&mut hidden_state, &attn_proj);"
-    )?;
+    if is_q8 {
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
+    } else {
+        writeln!(
+            code,
+            "        matmul_vec_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
+    }
+    writeln!(code, "        residual_add(&mut hidden_state, &attn_proj);")?;
     writeln!(code)?;
     writeln!(code, "        // FFN norm")?;
     writeln!(
@@ -769,31 +1011,51 @@ fn emit_forward_function(
         code,
         "        // FFN: fused silu_mul eliminates gate_act buffer"
     )?;
-    writeln!(
-        code,
-        "        matmul_vec_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
-        hidden = hidden, intermediate = intermediate
-    )?;
-    writeln!(
-        code,
-        "        matmul_vec_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
-        hidden = hidden, intermediate = intermediate
-    )?;
-    writeln!(
-        code,
-        "        silu_mul(&mut ffn_hidden, &gate, &up);"
-    )?;
-    writeln!(
-        code,
-        "        matmul_vec_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
-        intermediate = intermediate, hidden = hidden
-    )?;
+    if is_q8 {
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+    } else {
+        writeln!(
+            code,
+            "        matmul_vec_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+    }
+    writeln!(code, "        silu_mul(&mut ffn_hidden, &gate, &up);")?;
+    if is_q8 {
+        writeln!(
+            code,
+            "        matmul_vec_q8_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate, hidden = hidden
+        )?;
+    } else {
+        writeln!(
+            code,
+            "        matmul_vec_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate,
+            hidden = hidden
+        )?;
+    }
     writeln!(code)?;
     writeln!(code, "        // Fused residual add")?;
-    writeln!(
-        code,
-        "        residual_add(&mut hidden_state, &ffn_out);"
-    )?;
+    writeln!(code, "        residual_add(&mut hidden_state, &ffn_out);")?;
     writeln!(code, "    }}")?;
     writeln!(code)?;
 
@@ -804,8 +1066,14 @@ fn emit_forward_function(
         "    rms_norm(&mut normed, &hidden_state, &weights.final_norm, RMS_NORM_EPS);"
     )?;
     writeln!(code)?;
-    writeln!(code, "    // Logits projection (parallelized — largest single matmul)")?;
-    writeln!(code, "    // Uses larger chunks (256) to amortize Rayon overhead")?;
+    writeln!(
+        code,
+        "    // Logits projection (parallelized — largest single matmul)"
+    )?;
+    writeln!(
+        code,
+        "    // Uses larger chunks (256) to amortize Rayon overhead"
+    )?;
     writeln!(code, "    let mut logits = vec![0.0f32; VOCAB_SIZE];")?;
     writeln!(
         code,
@@ -813,14 +1081,19 @@ fn emit_forward_function(
     )?;
     writeln!(code, "        let base = chunk_idx * 256;")?;
     writeln!(code, "        for r in 0..out.len() {{")?;
-    writeln!(
-        code,
-        "            let j = base + r;"
-    )?;
-    writeln!(
-        code,
-        "            out[r] = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
-    )?;
+    writeln!(code, "            let j = base + r;")?;
+    if is_q8 {
+        let lm_row_bytes = hidden.div_ceil(32) * 34;
+        writeln!(
+            code,
+            "            out[r] = dot_q8_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
+        )?;
+    } else {
+        writeln!(
+            code,
+            "            out[r] = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
+        )?;
+    }
     writeln!(code, "        }}")?;
     writeln!(code, "    }});")?;
     writeln!(code)?;
@@ -939,11 +1212,11 @@ mod tests {
         assert!(code.contains("pub const NUM_LAYERS: usize = 30;"));
 
         // Shape-specialized matmul: hidden=576, qk=9*64=576, kv=3*64=192, inter=1536
-        assert!(code.contains("fn matmul_vec_576x576("));  // q_proj (hidden→qk)
-        assert!(code.contains("fn matmul_vec_576x192("));  // k/v_proj (hidden→kv)
+        assert!(code.contains("fn matmul_vec_576x576(")); // q_proj (hidden→qk)
+        assert!(code.contains("fn matmul_vec_576x192(")); // k/v_proj (hidden→kv)
         assert!(code.contains("fn matmul_vec_576x1536(")); // gate/up_proj
         assert!(code.contains("fn matmul_vec_1536x576(")); // down_proj
-        // Forward function uses specialized calls
+                                                           // Forward function uses specialized calls
         assert!(code.contains("matmul_vec_576x576(&mut q"));
         assert!(code.contains("matmul_vec_576x192(&mut k"));
         assert!(!code.contains("matmul(&mut q")); // no generic matmul calls
@@ -1114,5 +1387,130 @@ mod tests {
         let code = generate(&graph).unwrap();
 
         assert!(code.contains("#![allow(dead_code, unused_imports, unused_assignments)]"));
+    }
+
+    fn tiny_q8_config() -> ModelConfig {
+        ModelConfig {
+            architecture: Architecture::Llama,
+            hidden_size: 64,
+            intermediate_size: 128,
+            num_layers: 2,
+            num_attention_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 16,
+            vocab_size: 256,
+            max_seq_len: 64,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            dtype: DType::Q8_0,
+        }
+    }
+
+    #[test]
+    fn q8_0_model_generates_vec_u8_fields() {
+        let config = tiny_q8_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Projection weights should be Vec<u8>
+        assert!(
+            code.contains("pub q_proj: Vec<u8>"),
+            "q_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub k_proj: Vec<u8>"),
+            "k_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub v_proj: Vec<u8>"),
+            "v_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub o_proj: Vec<u8>"),
+            "o_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub gate_proj: Vec<u8>"),
+            "gate_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub up_proj: Vec<u8>"),
+            "up_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub down_proj: Vec<u8>"),
+            "down_proj should be Vec<u8> for Q8_0 model"
+        );
+        assert!(
+            code.contains("pub lm_head: Vec<u8>"),
+            "lm_head should be Vec<u8> for Q8_0 model"
+        );
+        // Norm and embedding weights are always f32
+        assert!(
+            code.contains("pub attn_norm: Vec<f32>"),
+            "attn_norm should remain Vec<f32>"
+        );
+        assert!(
+            code.contains("pub embed_tokens: Vec<f32>"),
+            "embed_tokens should remain Vec<f32>"
+        );
+        assert!(
+            code.contains("pub final_norm: Vec<f32>"),
+            "final_norm should remain Vec<f32>"
+        );
+    }
+
+    #[test]
+    fn q8_0_model_generates_dot_q8_0_function() {
+        let config = tiny_q8_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        assert!(
+            code.contains("fn dot_q8_0("),
+            "Q8_0 model should emit dot_q8_0 function"
+        );
+        assert!(
+            code.contains("fn f16_bits_to_f32("),
+            "Q8_0 model should emit f16_bits_to_f32 helper"
+        );
+    }
+
+    #[test]
+    fn q8_0_model_calls_q8_matmul_in_forward() {
+        let config = tiny_q8_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Forward function should use q8_0 matmul variants
+        assert!(
+            code.contains("matmul_vec_q8_0_"),
+            "Q8_0 model should call matmul_vec_q8_0_* variants"
+        );
+        // Should not use regular f32 matmul for projections in forward
+        assert!(
+            !code.contains("matmul_vec_64x64(&mut q"),
+            "Q8_0 model should not call f32 matmul for q_proj"
+        );
+    }
+
+    #[test]
+    fn f32_model_does_not_generate_q8_0_kernels() {
+        let config = tiny_config(); // F16 dtype
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Non-Q8_0 models should not have q8_0 functions
+        assert!(
+            !code.contains("fn dot_q8_0("),
+            "non-Q8_0 model should not emit dot_q8_0"
+        );
+        assert!(
+            !code.contains("matmul_vec_q8_0_"),
+            "non-Q8_0 model should not emit Q8_0 matmul variants"
+        );
+        // Should use regular Vec<f32> for all weight fields
+        assert!(code.contains("pub q_proj: Vec<f32>"));
+        assert!(code.contains("pub lm_head: Vec<f32>"));
     }
 }

--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -90,6 +90,145 @@ fn generate_main(config: &ModelConfig) -> String {
     let num_layers = config.num_layers;
     let qk_size = num_heads * head_dim;
     let kv_size = num_kv_heads * head_dim;
+    let is_q8 = config.dtype == DType::Q8_0;
+
+    // Pre-compute Q8_0 row byte sizes (ceil(numel/32)*34 per row)
+    let q8_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 34 };
+
+    // Byte sizes for Q8_0 weight tensors
+    let qp_bytes = qk_size * q8_row_bytes(hidden);
+    let kp_bytes = kv_size * q8_row_bytes(hidden);
+    let vp_bytes = kv_size * q8_row_bytes(hidden);
+    let op_bytes = hidden * q8_row_bytes(qk_size);
+    let gp_bytes = inter * q8_row_bytes(hidden);
+    let up_bytes = inter * q8_row_bytes(hidden);
+    let dp_bytes = hidden * q8_row_bytes(inter);
+    let lmh_bytes = vocab * q8_row_bytes(hidden);
+
+    let weight_loading_code = if is_q8 {
+        // Q8_0: load raw bytes; norm/embed are still f32
+        r##"fn load_weights_q8(path: &str) -> Vec<u8> {
+    let file = std::fs::File::open(path).expect("failed to open weights");
+    let mmap = unsafe { memmap2::Mmap::map(&file) }.expect("failed to mmap weights");
+    mmap.to_vec()
+}
+"##
+        .to_string()
+    } else {
+        r##"fn load_weights(path: &str) -> Vec<f32> {
+    let file = std::fs::File::open(path).expect("failed to open weights");
+    let mmap = unsafe { memmap2::Mmap::map(&file) }.expect("failed to mmap weights");
+    // Fast path: direct memcpy from mmap to f32 Vec (assumes little-endian, aligned)
+    let n = mmap.len() / 4;
+    let mut out = Vec::<f32>::with_capacity(n);
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            mmap.as_ptr() as *const f32,
+            out.as_mut_ptr(),
+            n,
+        );
+        out.set_len(n);
+    }
+    out
+}
+"##
+        .to_string()
+    };
+
+    let weight_slice_code = if is_q8 {
+        // Q8_0: byte offsets for projection weights, f32 element offsets for norm/embed
+        format!(
+            r##"    let w = load_weights_q8(weights_path);
+    let mut boff = 0usize;  // byte offset into raw buffer
+
+    // embed_tokens: f32, interpreted from raw bytes
+    let embed_bytes = {vocab} * {hidden} * 4;
+    let embed: Vec<f32> = {{
+        let n = embed_bytes / 4;
+        let mut v = Vec::<f32>::with_capacity(n);
+        unsafe {{
+            std::ptr::copy_nonoverlapping(w[boff..boff+embed_bytes].as_ptr() as *const f32, v.as_mut_ptr(), n);
+            v.set_len(n);
+        }}
+        v
+    }};
+    boff += embed_bytes;
+    let mut layers = Vec::new();
+    for _ in 0..{num_layers} {{
+        // attn_norm: f32
+        let an_bytes = {hidden} * 4;
+        let an: Vec<f32> = {{
+            let n = an_bytes / 4;
+            let mut v = Vec::<f32>::with_capacity(n);
+            unsafe {{
+                std::ptr::copy_nonoverlapping(w[boff..boff+an_bytes].as_ptr() as *const f32, v.as_mut_ptr(), n);
+                v.set_len(n);
+            }}
+            v
+        }};
+        boff += an_bytes;
+        // Projection weights: Q8_0 raw bytes
+        let qp = w[boff..boff+{qp_bytes}].to_vec(); boff += {qp_bytes};
+        let kp = w[boff..boff+{kp_bytes}].to_vec(); boff += {kp_bytes};
+        let vp = w[boff..boff+{vp_bytes}].to_vec(); boff += {vp_bytes};
+        let op = w[boff..boff+{op_bytes}].to_vec(); boff += {op_bytes};
+        // ffn_norm: f32
+        let fn_bytes = {hidden} * 4;
+        let fn_: Vec<f32> = {{
+            let n = fn_bytes / 4;
+            let mut v = Vec::<f32>::with_capacity(n);
+            unsafe {{
+                std::ptr::copy_nonoverlapping(w[boff..boff+fn_bytes].as_ptr() as *const f32, v.as_mut_ptr(), n);
+                v.set_len(n);
+            }}
+            v
+        }};
+        boff += fn_bytes;
+        let gp = w[boff..boff+{gp_bytes}].to_vec(); boff += {gp_bytes};
+        let up = w[boff..boff+{up_bytes}].to_vec(); boff += {up_bytes};
+        let dp = w[boff..boff+{dp_bytes}].to_vec(); boff += {dp_bytes};
+        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
+    }}
+    // final_norm: f32
+    let fnorm_bytes = {hidden} * 4;
+    let fnorm: Vec<f32> = {{
+        let n = fnorm_bytes / 4;
+        let mut v = Vec::<f32>::with_capacity(n);
+        unsafe {{
+            std::ptr::copy_nonoverlapping(w[boff..boff+fnorm_bytes].as_ptr() as *const f32, v.as_mut_ptr(), n);
+            v.set_len(n);
+        }}
+        v
+    }};
+    boff += fnorm_bytes;
+    // lm_head: Q8_0 raw bytes
+    let lmh = w[boff..boff+{lmh_bytes}].to_vec();
+    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
+        )
+    } else {
+        format!(
+            r##"    let w = load_weights(weights_path);
+    let mut off = 0usize;
+
+    let embed = w[off..off + {vocab} * {hidden}].to_vec(); off += {vocab} * {hidden};
+    let mut layers = Vec::new();
+    for _ in 0..{num_layers} {{
+        let an = w[off..off+{hidden}].to_vec(); off += {hidden};
+        let qp = w[off..off+{qk_size}*{hidden}].to_vec(); off += {qk_size}*{hidden};
+        let kp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
+        let vp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
+        let op = w[off..off+{hidden}*{qk_size}].to_vec(); off += {hidden}*{qk_size};
+        let fn_ = w[off..off+{hidden}].to_vec(); off += {hidden};
+        let gp = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
+        let up = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
+        let dp = w[off..off+{hidden}*{inter}].to_vec(); off += {hidden}*{inter};
+        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
+    }}
+    let fnorm = w[off..off+{hidden}].to_vec(); off += {hidden};
+    let lmh = w[off..off+{vocab}*{hidden}].to_vec();
+    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
+        )
+    };
 
     format!(
         r##"//! AOT-compiled inference binary generated by ForgeLLM.
@@ -100,22 +239,7 @@ mod model;
 use std::env;
 use std::io::Write;
 
-fn load_weights(path: &str) -> Vec<f32> {{
-    let file = std::fs::File::open(path).expect("failed to open weights");
-    let mmap = unsafe {{ memmap2::Mmap::map(&file) }}.expect("failed to mmap weights");
-    // Fast path: direct memcpy from mmap to f32 Vec (assumes little-endian, aligned)
-    let n = mmap.len() / 4;
-    let mut out = Vec::<f32>::with_capacity(n);
-    unsafe {{
-        std::ptr::copy_nonoverlapping(
-            mmap.as_ptr() as *const f32,
-            out.as_mut_ptr(),
-            n,
-        );
-        out.set_len(n);
-    }}
-    out
-}}
+{weight_loading_code}
 
 fn save_kv_cache(path: &str, cache: &model::KVCache) {{
     let kv = {kv_size};
@@ -267,27 +391,8 @@ fn main() {{
     let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_path).expect("failed to load tokenizer");
 
     eprintln!("Loading weights...");
-    let w = load_weights(weights_path);
+{weight_slice_code}
     eprintln!("Load time: {{:.2}}s", t_load.elapsed().as_secs_f64());
-    let mut off = 0usize;
-
-    let embed = w[off..off + {vocab} * {hidden}].to_vec(); off += {vocab} * {hidden};
-    let mut layers = Vec::new();
-    for _ in 0..{num_layers} {{
-        let an = w[off..off+{hidden}].to_vec(); off += {hidden};
-        let qp = w[off..off+{qk_size}*{hidden}].to_vec(); off += {qk_size}*{hidden};
-        let kp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
-        let vp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
-        let op = w[off..off+{hidden}*{qk_size}].to_vec(); off += {hidden}*{qk_size};
-        let fn_ = w[off..off+{hidden}].to_vec(); off += {hidden};
-        let gp = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
-        let up = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
-        let dp = w[off..off+{hidden}*{inter}].to_vec(); off += {hidden}*{inter};
-        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
-    }}
-    let fnorm = w[off..off+{hidden}].to_vec(); off += {hidden};
-    let lmh = w[off..off+{vocab}*{hidden}].to_vec();
-    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};
     let mut cache = model::KVCache::new();
     if let Some(ref cp) = load_cache_path {{ load_kv_cache(cp, &mut cache); }}
 
@@ -387,6 +492,97 @@ fn generate_main_embedded(config: &ModelConfig) -> String {
     let num_layers = config.num_layers;
     let qk_size = num_heads * head_dim;
     let kv_size = num_kv_heads * head_dim;
+    let is_q8 = config.dtype == DType::Q8_0;
+
+    let q8_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 34 };
+    let qp_bytes = qk_size * q8_row_bytes(hidden);
+    let kp_bytes = kv_size * q8_row_bytes(hidden);
+    let vp_bytes = kv_size * q8_row_bytes(hidden);
+    let op_bytes = hidden * q8_row_bytes(qk_size);
+    let gp_bytes = inter * q8_row_bytes(hidden);
+    let up_bytes = inter * q8_row_bytes(hidden);
+    let dp_bytes = hidden * q8_row_bytes(inter);
+    let lmh_bytes = vocab * q8_row_bytes(hidden);
+
+    let bytes_helper = if is_q8 {
+        // For Q8_0, we only need the bytes_to_f32 helper for norm/embed extraction
+        r##"fn bytes_to_f32_slice(bytes: &[u8]) -> Vec<f32> {
+    let n = bytes.len() / 4;
+    let mut out = Vec::<f32>::with_capacity(n);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const f32, out.as_mut_ptr(), n);
+        out.set_len(n);
+    }
+    out
+}
+"##
+        .to_string()
+    } else {
+        r##"fn bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    let n = bytes.len() / 4;
+    let mut out = Vec::<f32>::with_capacity(n);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const f32, out.as_mut_ptr(), n);
+        out.set_len(n);
+    }
+    out
+}
+"##
+        .to_string()
+    };
+
+    let weight_slice_code_embedded = if is_q8 {
+        format!(
+            r##"    let w: &[u8] = WEIGHTS_BYTES;
+    let mut boff = 0usize;
+
+    let embed_bytes = {vocab} * {hidden} * 4;
+    let embed = bytes_to_f32_slice(&w[boff..boff+embed_bytes]);
+    boff += embed_bytes;
+    let mut layers = Vec::new();
+    for _ in 0..{num_layers} {{
+        let an_bytes = {hidden} * 4;
+        let an = bytes_to_f32_slice(&w[boff..boff+an_bytes]); boff += an_bytes;
+        let qp = w[boff..boff+{qp_bytes}].to_vec(); boff += {qp_bytes};
+        let kp = w[boff..boff+{kp_bytes}].to_vec(); boff += {kp_bytes};
+        let vp = w[boff..boff+{vp_bytes}].to_vec(); boff += {vp_bytes};
+        let op = w[boff..boff+{op_bytes}].to_vec(); boff += {op_bytes};
+        let fn_bytes = {hidden} * 4;
+        let fn_ = bytes_to_f32_slice(&w[boff..boff+fn_bytes]); boff += fn_bytes;
+        let gp = w[boff..boff+{gp_bytes}].to_vec(); boff += {gp_bytes};
+        let up = w[boff..boff+{up_bytes}].to_vec(); boff += {up_bytes};
+        let dp = w[boff..boff+{dp_bytes}].to_vec(); boff += {dp_bytes};
+        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
+    }}
+    let fnorm_bytes = {hidden} * 4;
+    let fnorm = bytes_to_f32_slice(&w[boff..boff+fnorm_bytes]); boff += fnorm_bytes;
+    let lmh = w[boff..boff+{lmh_bytes}].to_vec();
+    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
+        )
+    } else {
+        format!(
+            r##"    let w = bytes_to_f32(WEIGHTS_BYTES);
+    let mut off = 0usize;
+
+    let embed = w[off..off + {vocab} * {hidden}].to_vec(); off += {vocab} * {hidden};
+    let mut layers = Vec::new();
+    for _ in 0..{num_layers} {{
+        let an = w[off..off+{hidden}].to_vec(); off += {hidden};
+        let qp = w[off..off+{qk_size}*{hidden}].to_vec(); off += {qk_size}*{hidden};
+        let kp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
+        let vp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
+        let op = w[off..off+{hidden}*{qk_size}].to_vec(); off += {hidden}*{qk_size};
+        let fn_ = w[off..off+{hidden}].to_vec(); off += {hidden};
+        let gp = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
+        let up = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
+        let dp = w[off..off+{hidden}*{inter}].to_vec(); off += {hidden}*{inter};
+        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
+    }}
+    let fnorm = w[off..off+{hidden}].to_vec(); off += {hidden};
+    let lmh = w[off..off+{vocab}*{hidden}].to_vec();
+    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
+        )
+    };
 
     format!(
         r##"//! AOT-compiled inference binary generated by ForgeLLM.
@@ -401,15 +597,7 @@ use std::io::Write;
 static WEIGHTS_BYTES: &[u8] = include_bytes!("../weights.bin");
 static TOKENIZER_BYTES: &[u8] = include_bytes!("../tokenizer.json");
 
-fn bytes_to_f32(bytes: &[u8]) -> Vec<f32> {{
-    let n = bytes.len() / 4;
-    let mut out = Vec::<f32>::with_capacity(n);
-    unsafe {{
-        std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const f32, out.as_mut_ptr(), n);
-        out.set_len(n);
-    }}
-    out
-}}
+{bytes_helper}
 
 fn save_kv_cache(path: &str, cache: &model::KVCache) {{
     let kv = {kv_size};
@@ -522,27 +710,8 @@ fn main() {{
     let tokenizer = tokenizers::Tokenizer::from_bytes(TOKENIZER_BYTES).expect("failed to load tokenizer");
 
     eprintln!("Parsing weights (embedded, {{:.1}} MB)...", WEIGHTS_BYTES.len() as f64 / 1e6);
-    let w = bytes_to_f32(WEIGHTS_BYTES);
+{weight_slice_code_embedded}
     eprintln!("Load time: {{:.2}}s", t_load.elapsed().as_secs_f64());
-    let mut off = 0usize;
-
-    let embed = w[off..off + {vocab} * {hidden}].to_vec(); off += {vocab} * {hidden};
-    let mut layers = Vec::new();
-    for _ in 0..{num_layers} {{
-        let an = w[off..off+{hidden}].to_vec(); off += {hidden};
-        let qp = w[off..off+{qk_size}*{hidden}].to_vec(); off += {qk_size}*{hidden};
-        let kp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
-        let vp = w[off..off+{kv_size}*{hidden}].to_vec(); off += {kv_size}*{hidden};
-        let op = w[off..off+{hidden}*{qk_size}].to_vec(); off += {hidden}*{qk_size};
-        let fn_ = w[off..off+{hidden}].to_vec(); off += {hidden};
-        let gp = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
-        let up = w[off..off+{inter}*{hidden}].to_vec(); off += {inter}*{hidden};
-        let dp = w[off..off+{hidden}*{inter}].to_vec(); off += {hidden}*{inter};
-        layers.push(model::LayerWeights {{ attn_norm: an, q_proj: qp, k_proj: kp, v_proj: vp, o_proj: op, ffn_norm: fn_, gate_proj: gp, up_proj: up, down_proj: dp }});
-    }}
-    let fnorm = w[off..off+{hidden}].to_vec(); off += {hidden};
-    let lmh = w[off..off+{vocab}*{hidden}].to_vec();
-    let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};
     let mut cache = model::KVCache::new();
     if let Some(ref cp) = load_cache_path {{ load_kv_cache(cp, &mut cache); }}
 
@@ -712,11 +881,22 @@ mod tests {
 
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
         // Find /clear handler and verify it uses cache.reset()
-        let clear_idx = main.find("if input == \"/clear\"").expect("clear handler missing");
-        let after_clear = &main[clear_idx..clear_idx+200];
-        assert!(after_clear.contains("cache.reset()"), "expected cache.reset() in /clear handler");
-        assert!(after_clear.contains("recent_tokens.clear()"), "expected recent_tokens.clear() in /clear handler");
-        assert!(!after_clear.contains("KVCache::new()"), "should not re-allocate cache on /clear");
+        let clear_idx = main
+            .find("if input == \"/clear\"")
+            .expect("clear handler missing");
+        let after_clear = &main[clear_idx..clear_idx + 200];
+        assert!(
+            after_clear.contains("cache.reset()"),
+            "expected cache.reset() in /clear handler"
+        );
+        assert!(
+            after_clear.contains("recent_tokens.clear()"),
+            "expected recent_tokens.clear() in /clear handler"
+        );
+        assert!(
+            !after_clear.contains("KVCache::new()"),
+            "should not re-allocate cache on /clear"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -732,7 +912,10 @@ mod tests {
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
         assert!(main.contains("--seed"), "should support --seed flag");
         assert!(main.contains("let seed = "), "should parse seed");
-        assert!(main.contains("let mut rng_state: u64 = seed;"), "should use parsed seed");
+        assert!(
+            main.contains("let mut rng_state: u64 = seed;"),
+            "should use parsed seed"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -746,8 +929,14 @@ mod tests {
         generate_project(&graph, &dir, "test-ver", false).unwrap();
 
         let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
-        assert!(main.contains("KV cache:"), "version output should show KV cache size");
-        assert!(main.contains("kv_bytes"), "should compute KV bytes from constants");
+        assert!(
+            main.contains("KV cache:"),
+            "version output should show KV cache size"
+        );
+        assert!(
+            main.contains("kv_bytes"),
+            "should compute KV bytes from constants"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/forgellm-frontend/src/weight_loader.rs
+++ b/crates/forgellm-frontend/src/weight_loader.rs
@@ -9,6 +9,109 @@ use std::path::Path;
 
 use crate::gguf::{self, GGMLType, GGUFFile, GGUFTensorInfo};
 
+/// Raw weight data — either f32 (dequantized) or Q8_0 raw bytes.
+#[derive(Debug, Clone)]
+pub enum WeightData {
+    /// Fully dequantized f32 tensor.
+    F32(Vec<f32>),
+    /// Raw Q8_0 bytes: N_blocks * 34 bytes each block = [2 bytes f16 scale][32 bytes int8].
+    Q8_0Raw(Vec<u8>),
+}
+
+/// Model weights with mixed storage: Q8_0 kept as raw bytes, others as f32.
+#[derive(Debug, Clone)]
+pub struct ModelWeightsRaw {
+    pub tensors: HashMap<String, WeightData>,
+}
+
+impl ModelWeightsRaw {
+    /// Get an f32 tensor by name.
+    pub fn get_f32(&self, name: &str) -> Option<&[f32]> {
+        match self.tensors.get(name) {
+            Some(WeightData::F32(v)) => Some(v.as_slice()),
+            _ => None,
+        }
+    }
+
+    /// Get a Q8_0 raw byte tensor by name.
+    pub fn get_q8_raw(&self, name: &str) -> Option<&[u8]> {
+        match self.tensors.get(name) {
+            Some(WeightData::Q8_0Raw(v)) => Some(v.as_slice()),
+            _ => None,
+        }
+    }
+
+    /// Number of loaded tensors.
+    pub fn len(&self) -> usize {
+        self.tensors.len()
+    }
+
+    /// Whether no tensors are loaded.
+    pub fn is_empty(&self) -> bool {
+        self.tensors.is_empty()
+    }
+
+    /// Total memory usage in bytes.
+    pub fn memory_bytes(&self) -> usize {
+        self.tensors
+            .values()
+            .map(|v| match v {
+                WeightData::F32(f) => f.len() * 4,
+                WeightData::Q8_0Raw(b) => b.len(),
+            })
+            .sum()
+    }
+
+    /// Get a tensor by name regardless of type — for non-Q8_0 tensors only.
+    pub fn get(&self, name: &str) -> Option<&WeightData> {
+        self.tensors.get(name)
+    }
+}
+
+/// Load all tensors from a GGUF file with mixed storage:
+/// - Q8_0 tensors are kept as raw bytes (`WeightData::Q8_0Raw`)
+/// - All other tensor types are dequantized to f32 (`WeightData::F32`)
+pub fn load_from_file_mixed(
+    path: impl AsRef<std::path::Path>,
+) -> Result<(crate::gguf::GGUFFile, ModelWeightsRaw), WeightLoadError> {
+    let file = std::fs::File::open(path.as_ref())?;
+    let mmap = unsafe { memmap2::Mmap::map(&file)? };
+    let mut cursor = std::io::Cursor::new(&mmap[..]);
+
+    let gguf = crate::gguf::parse(&mut cursor)
+        .map_err(|e| WeightLoadError::Io(std::io::Error::other(e)))?;
+
+    let mut tensors = HashMap::with_capacity(gguf.tensors.len());
+    for tensor_info in &gguf.tensors {
+        let data_offset = gguf.tensor_data_offset + tensor_info.offset;
+        let data_size = tensor_info.data_size() as usize;
+        let numel = tensor_info.numel() as usize;
+
+        let start = data_offset as usize;
+        let end = start + data_size;
+        if end > mmap.len() {
+            return Err(WeightLoadError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!("tensor {} extends past end of file", tensor_info.name),
+            )));
+        }
+
+        let raw = &mmap[start..end];
+        let hf_name = gguf_name_to_hf(&tensor_info.name);
+
+        let weight_data = if tensor_info.ggml_type == crate::gguf::GGMLType::Q8_0 {
+            WeightData::Q8_0Raw(raw.to_vec())
+        } else {
+            let f32_data = dequantize(raw, tensor_info.ggml_type, numel)?;
+            WeightData::F32(f32_data)
+        };
+
+        tensors.insert(hf_name, weight_data);
+    }
+
+    Ok((gguf, ModelWeightsRaw { tensors }))
+}
+
 /// Loaded model weights — all tensors dequantized to f32.
 #[derive(Debug, Clone)]
 pub struct ModelWeights {
@@ -780,5 +883,28 @@ mod tests {
         assert_eq!(weights.memory_bytes(), 1200);
         assert_eq!(weights.get("w1").unwrap().len(), 100);
         assert_eq!(weights.tensor("w2").len(), 200);
+    }
+
+    #[test]
+    fn model_weights_raw_accessors() {
+        let mut tensors = HashMap::new();
+        tensors.insert("norm.weight".to_string(), WeightData::F32(vec![1.0f32; 64]));
+        tensors.insert(
+            "q_proj.weight".to_string(),
+            WeightData::Q8_0Raw(vec![0u8; 68]),
+        ); // 2 blocks * 34 bytes
+        let raw = ModelWeightsRaw { tensors };
+
+        assert_eq!(raw.len(), 2);
+        assert!(!raw.is_empty());
+        assert!(raw.get_f32("norm.weight").is_some());
+        assert_eq!(raw.get_f32("norm.weight").unwrap().len(), 64);
+        assert!(raw.get_q8_raw("q_proj.weight").is_some());
+        assert_eq!(raw.get_q8_raw("q_proj.weight").unwrap().len(), 68);
+        // Cross-type accessors should return None
+        assert!(raw.get_f32("q_proj.weight").is_none());
+        assert!(raw.get_q8_raw("norm.weight").is_none());
+        // Memory bytes: 64*4 + 68 = 256 + 68 = 324
+        assert_eq!(raw.memory_bytes(), 64 * 4 + 68);
     }
 }


### PR DESCRIPTION
## Summary
- Closes #54
- Keep Q8_0 weights as raw bytes (int8 + f16 scale blocks) instead of expanding to f32 at load time — ~2x smaller weight files for Q8_0 models (34 bytes/block vs 128 bytes for dequantized f32)
- Add `dot_q8_0()` kernel + `matmul_vec_q8_0_KxN()` variants emitted when `config.dtype == Q8_0`; projection weight fields in generated structs become `Vec<u8>`
- `cmd_export_weights` detects Q8_0 and writes raw bytes; both external-weights and `--embed-weights` (include_bytes!) paths handled
- Non-Q8_0 models are completely unaffected

## Test plan
- [ ] All 125 existing tests still pass (`cargo test --workspace`)
- [ ] 4 new Q8_0-specific emit tests: `Vec<u8>` fields, `dot_q8_0` emission, `matmul_vec_q8_0_*` calls, f32 path unchanged
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)