### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to ForgeLLM are documented here.
 
+## [0.4.0] — 2026-04-10
+
+### Added
+- **Quantized matmul without dequantization** (`perf`): Q8_0 weights are now kept as raw bytes (int8 + f16 scale blocks). Dot products are computed directly on Q8_0 values — ~2x smaller weight files, better cache utilization (#54)
+- **WASM compilation target** (`feat`): `forge compile --target wasm` generates a `wasm32-unknown-unknown` Rust project with SIMD128 dot product, `#[wasm_bindgen]` exports (`WasmModel::new`, `forward`, `reset_cache`), and a `pkg/model.js` JS glue layer for browser integration (#52)
+- **Speculative decoding** (`feat`): `forge speculative --draft <model> --target-model <model> --output <dir>` compiles both models as library crates and generates a speculative decoding runner — draft runs N tokens ahead, target verifies, accepts matching tokens with KV cache rollback on mismatch (#58)
+- **LoRA adapter support** (`feat`): `forge compile --lora <adapter.safetensors>` merges LoRA weights at compile time (`W += (alpha/rank) * B @ A`) — the AOT binary has adapted weights baked in with zero runtime overhead; supports SafeTensors format (#59)
+
+### Fixed
+- Resolved `clippy::too_many_arguments` lint in `cmd_compile` (refactored to `CompileArgs` struct) that was failing CI under `-D warnings`
+- Fixed `cargo fmt` failures across `main.rs`, `emit.rs`, and `project.rs`
+
 ## [Unreleased] — v0.3.1-dev
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forgellm-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-cpu"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-gpu"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-codegen-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "forgellm-frontend",
  "forgellm-optimizer",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-frontend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "memmap2",
  "pretty_assertions",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-optimizer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "forgellm-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "forgellm-frontend",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sauravpanda/forge-llm"
@@ -19,12 +19,12 @@ homepage = "https://forgellm.dev"
 
 [workspace.dependencies]
 # Internal crates
-forgellm-frontend = { version = "0.3.0", path = "crates/forgellm-frontend" }
-forgellm-optimizer = { version = "0.3.0", path = "crates/forgellm-optimizer" }
-forgellm-codegen-cpu = { version = "0.3.0", path = "crates/forgellm-codegen-cpu" }
-forgellm-codegen-wasm = { version = "0.3.0", path = "crates/forgellm-codegen-wasm" }
-forgellm-codegen-gpu = { version = "0.3.0", path = "crates/forgellm-codegen-gpu" }
-forgellm-runtime = { version = "0.3.0", path = "crates/forgellm-runtime" }
+forgellm-frontend = { version = "0.4.0", path = "crates/forgellm-frontend" }
+forgellm-optimizer = { version = "0.4.0", path = "crates/forgellm-optimizer" }
+forgellm-codegen-cpu = { version = "0.4.0", path = "crates/forgellm-codegen-cpu" }
+forgellm-codegen-wasm = { version = "0.4.0", path = "crates/forgellm-codegen-wasm" }
+forgellm-codegen-gpu = { version = "0.4.0", path = "crates/forgellm-codegen-gpu" }
+forgellm-runtime = { version = "0.4.0", path = "crates/forgellm-runtime" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Bump workspace version to 0.4.0 and update CHANGELOG with features shipped in this release cycle: quantized matmul (#54), WASM target (#52), speculative decoding (#58), LoRA adapter support (#59), CI fixes (#118).