### PR TITLE
ci: perf regression detection for codegen benchmarks

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -27,8 +27,7 @@ jobs:
           key: bench
 
       - name: Run benchmarks on PR branch
-        run: |
-          cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/pr-bench.txt
+        run: cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/pr-bench.txt
 
       - name: Checkout base branch
         run: |
@@ -36,96 +35,11 @@ jobs:
           git checkout ${{ github.base_ref }}
 
       - name: Run benchmarks on base branch
-        run: |
-          cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/base-bench.txt
+        run: cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/base-bench.txt
 
       - name: Compare results and detect regressions
         id: compare
-        run: |
-          python3 - << 'EOF'
-          import re, sys, os
-
-          REGRESSION_THRESHOLD = 0.05  # 5%
-
-          # Convert criterion units to nanoseconds
-          UNIT_TO_NS = {
-              'ps': 1e-3, 'ns': 1.0,
-              'µs': 1e3, 'us': 1e3,
-              'ms': 1e6, 's': 1e9,
-          }
-
-          def parse_bench_txt(path):
-              """Parse criterion human-readable output.
-              Lines look like:
-                graph_build/tiny    time:   [1.234 µs  1.256 µs  1.278 µs]
-              The middle value is the point estimate.
-              """
-              results = {}
-              try:
-                  with open(path, encoding="utf-8", errors="replace") as f:
-                      for line in f:
-                          # Match: name <2+ spaces> time: <space> [lo unit <sp> mid unit <sp> hi unit]
-                          m = re.search(
-                              r'^(.+?)\s{2,}time:\s+\['
-                              r'[\d.]+ [a-zµ]+\s+'   # lower bound (skip)
-                              r'([\d.]+) ([a-zµ]+)\s+'  # point estimate
-                              r'[\d.]+ [a-zµ]+\s*\]',
-                              line,
-                          )
-                          if m:
-                              name = m.group(1).strip()
-                              val  = float(m.group(2))
-                              unit = m.group(3)
-                              ns   = val * UNIT_TO_NS.get(unit, 1.0)
-                              results[name] = ns
-              except FileNotFoundError:
-                  pass
-              return results
-
-          base = parse_bench_txt("/tmp/base-bench.txt")
-          pr   = parse_bench_txt("/tmp/pr-bench.txt")
-
-          if not base or not pr:
-              print("No benchmark data found — skipping comparison.")
-              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write("regression=false\n")
-              with open("/tmp/bench-summary.txt", "w") as f:
-                  f.write("No benchmark data available (benches may not have run).")
-              sys.exit(0)
-
-          rows = []
-          regression_found = False
-          for name in sorted(set(base) | set(pr)):
-              b = base.get(name, 0)
-              p = pr.get(name, 0)
-              if b == 0 or p == 0:
-                  rows.append(f"| `{name}` | N/A | N/A | N/A |")
-                  continue
-              ratio = (p - b) / b
-              pct = f"{ratio * 100:+.1f}%"
-              flag = ""
-              if ratio > REGRESSION_THRESHOLD:
-                  flag = " ⚠️ REGRESSION"
-                  regression_found = True
-              elif ratio < -0.05:
-                  flag = " ✅ improvement"
-              rows.append(f"| `{name}` | {b/1e6:.3f} ms | {p/1e6:.3f} ms | {pct}{flag} |")
-
-          table = "\n".join(rows)
-          summary = f"""### Benchmark comparison (base → PR)
-
-| Benchmark | Base (ms) | PR (ms) | Change |
-|-----------|-----------|---------|--------|
-{table}
-
-> Threshold: >{REGRESSION_THRESHOLD*100:.0f}% slowdown flagged as regression.
-"""
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"regression={'true' if regression_found else 'false'}\n")
-          with open("/tmp/bench-summary.txt", "w") as f:
-              f.write(summary)
-          EOF
+        run: python3 scripts/compare_bench.py
 
       - name: Read summary
         id: summary

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,0 +1,174 @@
+name: Perf Regression
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: Benchmark comparison
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need full history to checkout base branch
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bench
+
+      - name: Install cargo-criterion
+        run: cargo install cargo-criterion --locked
+
+      - name: Run benchmarks on PR branch
+        run: |
+          cargo criterion -p forgellm-codegen-cpu \
+            --output-format quiet \
+            --message-format json 2>&1 \
+            | tee /tmp/pr-bench.json || true
+          # Also capture raw criterion output
+          cargo criterion -p forgellm-codegen-cpu 2>&1 \
+            | tee /tmp/pr-bench.txt || true
+
+      - name: Checkout base branch
+        run: |
+          git stash || true
+          git checkout ${{ github.base_ref }}
+
+      - name: Run benchmarks on base branch
+        run: |
+          cargo criterion -p forgellm-codegen-cpu \
+            --output-format quiet \
+            --message-format json 2>&1 \
+            | tee /tmp/base-bench.json || true
+          cargo criterion -p forgellm-codegen-cpu 2>&1 \
+            | tee /tmp/base-bench.txt || true
+
+      - name: Compare results and detect regressions
+        id: compare
+        run: |
+          python3 - << 'EOF'
+          import json, sys, os
+
+          REGRESSION_THRESHOLD = 0.05  # 5%
+
+          def parse_criterion_json(path):
+              results = {}
+              try:
+                  with open(path) as f:
+                      for line in f:
+                          line = line.strip()
+                          if not line:
+                              continue
+                          try:
+                              obj = json.loads(line)
+                          except json.JSONDecodeError:
+                              continue
+                          if obj.get("reason") == "benchmark-complete":
+                              name = obj["id"]
+                              # mean estimate in nanoseconds
+                              mean_ns = obj.get("mean", {}).get("estimate", 0)
+                              results[name] = mean_ns
+              except FileNotFoundError:
+                  pass
+              return results
+
+          base = parse_criterion_json("/tmp/base-bench.json")
+          pr   = parse_criterion_json("/tmp/pr-bench.json")
+
+          if not base or not pr:
+              print("No benchmark data found — skipping comparison.")
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write("has_data=false\n")
+                  f.write("regression=false\n")
+                  f.write("summary=No benchmark data available.\n")
+              sys.exit(0)
+
+          rows = []
+          regression_found = False
+          for name in sorted(set(base) | set(pr)):
+              b = base.get(name, 0)
+              p = pr.get(name, 0)
+              if b == 0 or p == 0:
+                  rows.append(f"| {name} | N/A | N/A | N/A |")
+                  continue
+              ratio = (p - b) / b
+              pct = f"{ratio * 100:+.1f}%"
+              flag = ""
+              if ratio > REGRESSION_THRESHOLD:
+                  flag = " ⚠️ REGRESSION"
+                  regression_found = True
+              elif ratio < -0.05:
+                  flag = " ✅ improvement"
+              rows.append(f"| `{name}` | {b/1e6:.3f} ms | {p/1e6:.3f} ms | {pct}{flag} |")
+
+          table = "\n".join(rows)
+          summary = f"""### Benchmark comparison (base → PR)
+
+          | Benchmark | Base (ms) | PR (ms) | Change |
+          |-----------|-----------|---------|--------|
+          {table}
+
+          > Threshold: >{REGRESSION_THRESHOLD*100:.0f}% slowdown flagged as regression.
+          """
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"has_data=true\n")
+              f.write(f"regression={'true' if regression_found else 'false'}\n")
+              # Write summary via env file (multiline)
+          with open("/tmp/bench-summary.txt", "w") as f:
+              f.write(summary)
+          EOF
+
+      - name: Read summary
+        id: summary
+        run: |
+          if [ -f /tmp/bench-summary.txt ]; then
+            echo "body<<EOF" >> "$GITHUB_OUTPUT"
+            cat /tmp/bench-summary.txt >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "body=No benchmark data." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `${{ steps.summary.outputs.body }}`;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.data.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Benchmark comparison')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on regression
+        if: steps.compare.outputs.regression == 'true'
+        run: |
+          echo "Performance regression detected (>5% slowdown). See PR comment for details."
+          exit 1

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -23,18 +26,9 @@ jobs:
         with:
           key: bench
 
-      - name: Install cargo-criterion
-        run: cargo install cargo-criterion --locked
-
       - name: Run benchmarks on PR branch
         run: |
-          cargo criterion -p forgellm-codegen-cpu \
-            --output-format quiet \
-            --message-format json 2>&1 \
-            | tee /tmp/pr-bench.json || true
-          # Also capture raw criterion output
-          cargo criterion -p forgellm-codegen-cpu 2>&1 \
-            | tee /tmp/pr-bench.txt || true
+          cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/pr-bench.txt
 
       - name: Checkout base branch
         run: |
@@ -43,51 +37,60 @@ jobs:
 
       - name: Run benchmarks on base branch
         run: |
-          cargo criterion -p forgellm-codegen-cpu \
-            --output-format quiet \
-            --message-format json 2>&1 \
-            | tee /tmp/base-bench.json || true
-          cargo criterion -p forgellm-codegen-cpu 2>&1 \
-            | tee /tmp/base-bench.txt || true
+          cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/base-bench.txt
 
       - name: Compare results and detect regressions
         id: compare
         run: |
           python3 - << 'EOF'
-          import json, sys, os
+          import re, sys, os
 
           REGRESSION_THRESHOLD = 0.05  # 5%
 
-          def parse_criterion_json(path):
+          # Convert criterion units to nanoseconds
+          UNIT_TO_NS = {
+              'ps': 1e-3, 'ns': 1.0,
+              'µs': 1e3, 'us': 1e3,
+              'ms': 1e6, 's': 1e9,
+          }
+
+          def parse_bench_txt(path):
+              """Parse criterion human-readable output.
+              Lines look like:
+                graph_build/tiny    time:   [1.234 µs  1.256 µs  1.278 µs]
+              The middle value is the point estimate.
+              """
               results = {}
               try:
-                  with open(path) as f:
+                  with open(path, encoding="utf-8", errors="replace") as f:
                       for line in f:
-                          line = line.strip()
-                          if not line:
-                              continue
-                          try:
-                              obj = json.loads(line)
-                          except json.JSONDecodeError:
-                              continue
-                          if obj.get("reason") == "benchmark-complete":
-                              name = obj["id"]
-                              # mean estimate in nanoseconds
-                              mean_ns = obj.get("mean", {}).get("estimate", 0)
-                              results[name] = mean_ns
+                          # Match: name <2+ spaces> time: <space> [lo unit <sp> mid unit <sp> hi unit]
+                          m = re.search(
+                              r'^(.+?)\s{2,}time:\s+\['
+                              r'[\d.]+ [a-zµ]+\s+'   # lower bound (skip)
+                              r'([\d.]+) ([a-zµ]+)\s+'  # point estimate
+                              r'[\d.]+ [a-zµ]+\s*\]',
+                              line,
+                          )
+                          if m:
+                              name = m.group(1).strip()
+                              val  = float(m.group(2))
+                              unit = m.group(3)
+                              ns   = val * UNIT_TO_NS.get(unit, 1.0)
+                              results[name] = ns
               except FileNotFoundError:
                   pass
               return results
 
-          base = parse_criterion_json("/tmp/base-bench.json")
-          pr   = parse_criterion_json("/tmp/pr-bench.json")
+          base = parse_bench_txt("/tmp/base-bench.txt")
+          pr   = parse_bench_txt("/tmp/pr-bench.txt")
 
           if not base or not pr:
               print("No benchmark data found — skipping comparison.")
               with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write("has_data=false\n")
                   f.write("regression=false\n")
-                  f.write("summary=No benchmark data available.\n")
+              with open("/tmp/bench-summary.txt", "w") as f:
+                  f.write("No benchmark data available (benches may not have run).")
               sys.exit(0)
 
           rows = []
@@ -96,7 +99,7 @@ jobs:
               b = base.get(name, 0)
               p = pr.get(name, 0)
               if b == 0 or p == 0:
-                  rows.append(f"| {name} | N/A | N/A | N/A |")
+                  rows.append(f"| `{name}` | N/A | N/A | N/A |")
                   continue
               ratio = (p - b) / b
               pct = f"{ratio * 100:+.1f}%"
@@ -111,17 +114,15 @@ jobs:
           table = "\n".join(rows)
           summary = f"""### Benchmark comparison (base → PR)
 
-          | Benchmark | Base (ms) | PR (ms) | Change |
-          |-----------|-----------|---------|--------|
-          {table}
+| Benchmark | Base (ms) | PR (ms) | Change |
+|-----------|-----------|---------|--------|
+{table}
 
-          > Threshold: >{REGRESSION_THRESHOLD*100:.0f}% slowdown flagged as regression.
-          """
+> Threshold: >{REGRESSION_THRESHOLD*100:.0f}% slowdown flagged as regression.
+"""
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"has_data=true\n")
               f.write(f"regression={'true' if regression_found else 'false'}\n")
-              # Write summary via env file (multiline)
           with open("/tmp/bench-summary.txt", "w") as f:
               f.write(summary)
           EOF

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -27,7 +27,9 @@ jobs:
           key: bench
 
       - name: Run benchmarks on PR branch
-        run: cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/pr-bench.txt
+        run: |
+          cargo bench -p forgellm-codegen-cpu 2>&1 | tee /tmp/pr-bench.txt
+          cp scripts/compare_bench.py /tmp/compare_bench.py
 
       - name: Checkout base branch
         run: |
@@ -39,7 +41,7 @@ jobs:
 
       - name: Compare results and detect regressions
         id: compare
-        run: python3 scripts/compare_bench.py
+        run: python3 /tmp/compare_bench.py
 
       - name: Read summary
         id: summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +104,18 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -117,6 +141,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -180,6 +231,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +290,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -346,9 +439,11 @@ dependencies = [
 name = "forgellm-codegen-cpu"
 version = "0.4.0"
 dependencies = [
+ "criterion",
  "forgellm-frontend",
  "forgellm-optimizer",
  "pretty_assertions",
+ "tempfile",
  "thiserror",
  "tracing",
 ]
@@ -422,10 +517,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "ident_case"
@@ -434,10 +546,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -453,6 +585,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -566,6 +708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +773,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -706,7 +891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -773,6 +958,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -916,6 +1110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +1132,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -1055,12 +1259,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/forgellm-codegen-cpu/Cargo.toml
+++ b/crates/forgellm-codegen-cpu/Cargo.toml
@@ -15,3 +15,9 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "codegen"
+harness = false

--- a/crates/forgellm-codegen-cpu/benches/codegen.rs
+++ b/crates/forgellm-codegen-cpu/benches/codegen.rs
@@ -1,0 +1,103 @@
+//! Micro-benchmarks for ForgeLLM codegen performance.
+//!
+//! Measures IR graph building and Rust source emission speed.
+//! Used for perf regression detection in CI.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use forgellm_codegen_cpu::{generate, generate_project};
+use forgellm_frontend::{
+    graph_builder,
+    ir::{Architecture, DType, ModelConfig},
+};
+use std::hint::black_box;
+
+fn tiny_config() -> ModelConfig {
+    ModelConfig {
+        architecture: Architecture::Llama,
+        hidden_size: 64,
+        intermediate_size: 128,
+        num_layers: 2,
+        num_attention_heads: 4,
+        num_kv_heads: 4,
+        head_dim: 16,
+        vocab_size: 512,
+        max_seq_len: 512,
+        rms_norm_eps: 1e-5,
+        rope_theta: 10000.0,
+        dtype: DType::F32,
+    }
+}
+
+fn small_config() -> ModelConfig {
+    ModelConfig {
+        architecture: Architecture::Llama,
+        hidden_size: 576,
+        intermediate_size: 1536,
+        num_layers: 30,
+        num_attention_heads: 9,
+        num_kv_heads: 3,
+        head_dim: 64,
+        vocab_size: 49152,
+        max_seq_len: 4096,
+        rms_norm_eps: 1e-5,
+        rope_theta: 10000.0,
+        dtype: DType::F32,
+    }
+}
+
+fn bench_graph_build(c: &mut Criterion) {
+    let mut g = c.benchmark_group("graph_build");
+    g.bench_function("tiny", |b| {
+        b.iter(|| black_box(graph_builder::build_graph(black_box(&tiny_config()))))
+    });
+    g.bench_function("smollm2_135m", |b| {
+        b.iter(|| black_box(graph_builder::build_graph(black_box(&small_config()))))
+    });
+    g.finish();
+}
+
+fn bench_emit(c: &mut Criterion) {
+    let mut g = c.benchmark_group("emit");
+    let tiny_graph = graph_builder::build_graph(&tiny_config()).unwrap();
+    g.bench_function("tiny", |b| {
+        b.iter(|| black_box(generate(black_box(&tiny_graph)).unwrap()))
+    });
+    let small_graph = graph_builder::build_graph(&small_config()).unwrap();
+    g.bench_function("smollm2_135m", |b| {
+        b.iter(|| black_box(generate(black_box(&small_graph)).unwrap()))
+    });
+    g.finish();
+}
+
+fn bench_generate_project(c: &mut Criterion) {
+    let mut g = c.benchmark_group("generate_project");
+    let tiny_graph = graph_builder::build_graph(&tiny_config()).unwrap();
+    g.bench_function("tiny_f32", |b| {
+        b.iter(|| {
+            let dir = tempfile::tempdir().unwrap();
+            generate_project(black_box(&tiny_graph), dir.path(), "bench-model", false).unwrap();
+            black_box(dir)
+        })
+    });
+    g.finish();
+}
+
+fn bench_emit_sizes(c: &mut Criterion) {
+    let mut g = c.benchmark_group("emit_output_size");
+    for (name, config) in [("tiny", tiny_config()), ("smollm2_135m", small_config())] {
+        g.bench_with_input(BenchmarkId::new("bytes", name), &config, |b, cfg| {
+            let graph = graph_builder::build_graph(cfg).unwrap();
+            b.iter(|| black_box(generate(black_box(&graph)).unwrap().len()))
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_graph_build,
+    bench_emit,
+    bench_generate_project,
+    bench_emit_sizes,
+);
+criterion_main!(benches);

--- a/scripts/compare_bench.py
+++ b/scripts/compare_bench.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Compare criterion benchmark results between two cargo bench runs.
+
+Reads /tmp/base-bench.txt and /tmp/pr-bench.txt (criterion human-readable
+output captured via `cargo bench 2>&1 | tee`), computes percentage change
+per benchmark, writes a markdown summary to /tmp/bench-summary.txt, and
+sets GITHUB_OUTPUT variables `regression=true/false`.
+
+Criterion text output format:
+    graph_build/tiny    time:   [1.234 µs  1.256 µs  1.278 µs]
+The three values are lower_bound, point_estimate, upper_bound.
+"""
+import re
+import sys
+import os
+
+REGRESSION_THRESHOLD = 0.05  # 5%
+
+# Map criterion unit strings to nanoseconds
+UNIT_TO_NS = {
+    "ps": 1e-3,
+    "ns": 1.0,
+    "us": 1e3,
+    "\xb5s": 1e3,  # µs as latin-1
+    "ms": 1e6,
+    "s": 1e9,
+}
+
+
+def parse_unit(unit_str):
+    unit_str = unit_str.replace("\xb5", "u")  # normalize µ -> u
+    return UNIT_TO_NS.get(unit_str, 1.0)
+
+
+def parse_bench_txt(path):
+    """Return dict of {benchmark_name: point_estimate_ns}."""
+    results = {}
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                # e.g.: "graph_build/tiny    time:   [1.234 µs  1.256 µs  1.278 µs]"
+                m = re.search(
+                    r"^(.+?)\s{2,}time:\s+\["
+                    r"[\d.]+ \S+\s+"      # lower bound (skip)
+                    r"([\d.]+) (\S+)\s+"  # point estimate
+                    r"[\d.]+ \S+\s*\]",
+                    line,
+                )
+                if m:
+                    name = m.group(1).strip()
+                    val = float(m.group(2))
+                    unit = m.group(3)
+                    ns = val * parse_unit(unit)
+                    results[name] = ns
+    except FileNotFoundError:
+        pass
+    return results
+
+
+def main():
+    base = parse_bench_txt("/tmp/base-bench.txt")
+    pr = parse_bench_txt("/tmp/pr-bench.txt")
+
+    github_output = os.environ.get("GITHUB_OUTPUT", "/dev/stderr")
+
+    if not base or not pr:
+        print("No benchmark data found — skipping comparison.")
+        with open(github_output, "a") as f:
+            f.write("regression=false\n")
+        with open("/tmp/bench-summary.txt", "w") as f:
+            f.write("No benchmark data available (benches may not have run).\n")
+        return
+
+    rows = []
+    regression_found = False
+    for name in sorted(set(base) | set(pr)):
+        b = base.get(name, 0)
+        p = pr.get(name, 0)
+        if b == 0 or p == 0:
+            rows.append("| `{}` | N/A | N/A | N/A |".format(name))
+            continue
+        ratio = (p - b) / b
+        pct = "{:+.1f}%".format(ratio * 100)
+        flag = ""
+        if ratio > REGRESSION_THRESHOLD:
+            flag = " REGRESSION"
+            regression_found = True
+        elif ratio < -0.05:
+            flag = " improvement"
+        rows.append(
+            "| `{}` | {:.3f} ms | {:.3f} ms | {}{} |".format(
+                name, b / 1e6, p / 1e6, pct, flag
+            )
+        )
+
+    threshold_pct = int(REGRESSION_THRESHOLD * 100)
+    with open("/tmp/bench-summary.txt", "w") as f:
+        f.write("### Benchmark comparison (base vs PR)\n\n")
+        f.write("| Benchmark | Base (ms) | PR (ms) | Change |\n")
+        f.write("|-----------|-----------|---------|--------|\n")
+        for row in rows:
+            f.write(row + "\n")
+        f.write("\n> Threshold: >{}% slowdown flagged as regression.\n".format(threshold_pct))
+
+    with open(github_output, "a") as f:
+        f.write("regression={}\n".format("true" if regression_found else "false"))
+
+    if regression_found:
+        print("Performance regression detected!")
+    else:
+        print("No regressions detected.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds Criterion benchmarks (`bench_graph_build`, `bench_emit`, `bench_generate_project`, `bench_emit_output_size`) in `crates/forgellm-codegen-cpu/benches/codegen.rs`
- Adds GitHub Actions workflow (`.github/workflows/bench-pr.yml`) that runs benchmarks on both PR and base branches, posts a comparison table as a PR comment, and fails the check if any benchmark regresses more than 5%

## Test plan

- [ ] Verify `cargo bench -p forgellm-codegen-cpu` compiles and runs locally
- [ ] Open a test PR and confirm the workflow posts a comment with benchmark table
- [ ] Introduce an artificial regression and confirm the workflow fails with `exit 1`

Closes #129