### PR TITLE
perf: forward_prefill for whole-prompt batched processing

### DIFF
--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -31,6 +31,7 @@ pub fn generate(graph: &Graph) -> Result<String, CodegenError> {
     }
     emit_specialized_matmul_functions(&mut code, config)?;
     emit_forward_function(&mut code, graph, config)?;
+    emit_prefill_function(&mut code, config)?;
 
     Ok(code)
 }
@@ -1104,6 +1105,284 @@ fn emit_forward_function(
     Ok(())
 }
 
+/// Emit the `forward_prefill` function for batched prompt processing.
+///
+/// Processes a sequence of tokens in one pass, filling the KV cache for each
+/// token sequentially. Returns logits for the last token only — used to pick
+/// the first generated token. This avoids redundant tokenizer/function overhead
+/// compared to calling `forward()` in a loop.
+fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), CodegenError> {
+    let hidden = config.hidden_size;
+    let intermediate = config.intermediate_size;
+    let num_heads = config.num_attention_heads;
+    let num_kv_heads = config.num_kv_heads;
+    let head_dim = config.head_dim;
+    let qk_size = num_heads * head_dim;
+    let kv_size = num_kv_heads * head_dim;
+
+    let is_q8 = config.dtype == DType::Q8_0;
+
+    writeln!(code)?;
+    writeln!(code, "/// Process a prompt sequence and fill the KV cache.")?;
+    writeln!(
+        code,
+        "/// Returns logits for the last token — use these to start generation."
+    )?;
+    writeln!(
+        code,
+        "/// Avoids per-token tokenizer overhead compared to calling forward() in a loop."
+    )?;
+    writeln!(
+        code,
+        "pub fn forward_prefill(tokens: &[u32], weights: &Weights, cache: &mut KVCache) -> Vec<f32> {{"
+    )?;
+    writeln!(code, "    let seq_len = tokens.len();")?;
+    writeln!(code)?;
+    writeln!(
+        code,
+        "    // Precompute RoPE frequencies once for the entire prefill pass"
+    )?;
+    writeln!(
+        code,
+        "    let rope_freqs = rope_freqs(HEAD_DIM, ROPE_THETA);"
+    )?;
+    writeln!(code)?;
+    writeln!(
+        code,
+        "    // Fixed-size stack buffers — same as forward(), zero heap allocation"
+    )?;
+    writeln!(code, "    let mut hidden_state = [0.0f32; HIDDEN_SIZE];")?;
+    writeln!(code, "    let mut normed = [0.0f32; {hidden}];")?;
+    writeln!(code, "    let mut q = [0.0f32; {qk_size}];")?;
+    writeln!(code, "    let mut k = [0.0f32; {kv_size}];")?;
+    writeln!(code, "    let mut v = [0.0f32; {kv_size}];")?;
+    writeln!(code, "    let mut attn_out = [0.0f32; {qk_size}];")?;
+    writeln!(code, "    let mut attn_proj = [0.0f32; {hidden}];")?;
+    writeln!(code, "    let mut gate = [0.0f32; {intermediate}];")?;
+    writeln!(code, "    let mut up = [0.0f32; {intermediate}];")?;
+    writeln!(code, "    let mut ffn_hidden = [0.0f32; {intermediate}];")?;
+    writeln!(code, "    let mut ffn_out = [0.0f32; {hidden}];")?;
+    writeln!(code, "    let mut last_logits = vec![0.0f32; VOCAB_SIZE];")?;
+    writeln!(code)?;
+    writeln!(
+        code,
+        "    for (tok_pos, &token_id) in tokens.iter().enumerate() {{"
+    )?;
+    writeln!(code, "        let pos = cache.len + tok_pos;")?;
+    writeln!(code)?;
+    writeln!(code, "        // Embedding lookup")?;
+    writeln!(
+        code,
+        "        embedding(&mut hidden_state, token_id, &weights.embed_tokens, HIDDEN_SIZE);"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "        // Transformer layers")?;
+    writeln!(code, "        for layer_idx in 0..NUM_LAYERS {{")?;
+    writeln!(code, "            let lw = &weights.layers[layer_idx];")?;
+    writeln!(code)?;
+    writeln!(code, "            // Attention norm")?;
+    writeln!(
+        code,
+        "            rms_norm(&mut normed, &hidden_state, &lw.attn_norm, RMS_NORM_EPS);"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "            // QKV projections")?;
+    if is_q8 {
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+    } else {
+        writeln!(
+            code,
+            "            matmul_vec_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+    }
+    writeln!(code)?;
+    writeln!(code, "            // RoPE")?;
+    writeln!(
+        code,
+        "            rope(&mut q, pos, HEAD_DIM, NUM_HEADS, &rope_freqs);"
+    )?;
+    writeln!(
+        code,
+        "            rope(&mut k, pos, HEAD_DIM, NUM_KV_HEADS, &rope_freqs);"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "            // Update KV cache at current position")?;
+    writeln!(
+        code,
+        "            cache.k[layer_idx][pos*{kv_size}..(pos+1)*{kv_size}].copy_from_slice(&k);",
+        kv_size = kv_size
+    )?;
+    writeln!(
+        code,
+        "            cache.v[layer_idx][pos*{kv_size}..(pos+1)*{kv_size}].copy_from_slice(&v);",
+        kv_size = kv_size
+    )?;
+    writeln!(code)?;
+    writeln!(
+        code,
+        "            // Attention over all filled positions (causal: current token sees all previous + itself)"
+    )?;
+    writeln!(code, "            attention(")?;
+    writeln!(code, "                &mut attn_out, &q,")?;
+    writeln!(
+        code,
+        "                &cache.k[layer_idx][..(pos+1)*{kv_size}], &cache.v[layer_idx][..(pos+1)*{kv_size}],",
+        kv_size = kv_size
+    )?;
+    writeln!(
+        code,
+        "                pos + 1, NUM_HEADS, NUM_KV_HEADS, HEAD_DIM,"
+    )?;
+    writeln!(code, "            );")?;
+    writeln!(code)?;
+    writeln!(code, "            // Output projection + residual")?;
+    if is_q8 {
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
+    } else {
+        writeln!(
+            code,
+            "            matmul_vec_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
+    }
+    writeln!(
+        code,
+        "            residual_add(&mut hidden_state, &attn_proj);"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "            // FFN norm")?;
+    writeln!(
+        code,
+        "            rms_norm(&mut normed, &hidden_state, &lw.ffn_norm, RMS_NORM_EPS);"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "            // FFN: fused silu_mul")?;
+    if is_q8 {
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+    } else {
+        writeln!(
+            code,
+            "            matmul_vec_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+    }
+    writeln!(code, "            silu_mul(&mut ffn_hidden, &gate, &up);")?;
+    if is_q8 {
+        writeln!(
+            code,
+            "            matmul_vec_q8_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate,
+            hidden = hidden
+        )?;
+    } else {
+        writeln!(
+            code,
+            "            matmul_vec_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate,
+            hidden = hidden
+        )?;
+    }
+    writeln!(
+        code,
+        "            residual_add(&mut hidden_state, &ffn_out);"
+    )?;
+    writeln!(code, "        }}")?;
+    writeln!(code)?;
+    writeln!(
+        code,
+        "        // On the last token, compute logits for the first generated token"
+    )?;
+    writeln!(code, "        if tok_pos == seq_len - 1 {{")?;
+    writeln!(
+        code,
+        "            rms_norm(&mut normed, &hidden_state, &weights.final_norm, RMS_NORM_EPS);"
+    )?;
+    writeln!(
+        code,
+        "            last_logits.par_chunks_mut(256).enumerate().for_each(|(chunk_idx, out)| {{"
+    )?;
+    writeln!(code, "                let base = chunk_idx * 256;")?;
+    writeln!(code, "                for r in 0..out.len() {{")?;
+    writeln!(code, "                    let j = base + r;")?;
+    if is_q8 {
+        let lm_row_bytes = hidden.div_ceil(32) * 34;
+        writeln!(
+            code,
+            "                    out[r] = dot_q8_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
+        )?;
+    } else {
+        writeln!(
+            code,
+            "                    out[r] = dot_f32(&normed[..], &weights.lm_head[j*{hidden}..(j+1)*{hidden}], {hidden});"
+        )?;
+    }
+    writeln!(code, "                }}")?;
+    writeln!(code, "            }});")?;
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+    writeln!(code)?;
+    writeln!(code, "    cache.len += seq_len;")?;
+    writeln!(code, "    last_logits")?;
+    writeln!(code, "}}")?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1512,5 +1791,157 @@ mod tests {
         // Should use regular Vec<f32> for all weight fields
         assert!(code.contains("pub q_proj: Vec<f32>"));
         assert!(code.contains("pub lm_head: Vec<f32>"));
+    }
+
+    #[test]
+    fn generated_code_has_forward_prefill_function() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // forward_prefill function must exist
+        assert!(
+            code.contains("pub fn forward_prefill("),
+            "generated code should contain forward_prefill function"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_takes_slice_of_u32() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Signature: tokens: &[u32], not a single u32
+        assert!(
+            code.contains("forward_prefill(tokens: &[u32]"),
+            "forward_prefill should take &[u32] not a single u32"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_returns_vec_f32() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Return type must be Vec<f32>
+        assert!(
+            code.contains("forward_prefill(tokens: &[u32], weights: &Weights, cache: &mut KVCache) -> Vec<f32>"),
+            "forward_prefill should return Vec<f32>"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_body_calls_embedding_and_layer_kernels() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Find the forward_prefill function body and verify it calls key kernels
+        let prefill_start = code
+            .find("pub fn forward_prefill(")
+            .expect("forward_prefill not found");
+        let prefill_body = &code[prefill_start..];
+
+        assert!(
+            prefill_body.contains("embedding(&mut hidden_state"),
+            "forward_prefill should call embedding"
+        );
+        assert!(
+            prefill_body.contains("rms_norm("),
+            "forward_prefill should call rms_norm"
+        );
+        assert!(
+            prefill_body.contains("silu_mul("),
+            "forward_prefill should call silu_mul"
+        );
+        assert!(
+            prefill_body.contains("attention("),
+            "forward_prefill should call attention"
+        );
+        assert!(
+            prefill_body.contains("rope("),
+            "forward_prefill should call rope"
+        );
+        assert!(
+            prefill_body.contains("residual_add("),
+            "forward_prefill should call residual_add"
+        );
+        assert!(
+            prefill_body.contains("cache.len += seq_len"),
+            "forward_prefill should update cache.len by seq_len"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_fills_kv_cache_at_tok_pos() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        let prefill_start = code
+            .find("pub fn forward_prefill(")
+            .expect("forward_prefill not found");
+        let prefill_body = &code[prefill_start..];
+
+        // Cache should be written using `pos` (cache.len + tok_pos)
+        assert!(
+            prefill_body.contains("let pos = cache.len + tok_pos;"),
+            "forward_prefill should use cache.len + tok_pos as position"
+        );
+        assert!(
+            prefill_body.contains("cache.k[layer_idx][pos*"),
+            "forward_prefill should write to k cache at pos"
+        );
+        assert!(
+            prefill_body.contains("cache.v[layer_idx][pos*"),
+            "forward_prefill should write to v cache at pos"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_computes_logits_only_for_last_token() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        let prefill_start = code
+            .find("pub fn forward_prefill(")
+            .expect("forward_prefill not found");
+        let prefill_body = &code[prefill_start..];
+
+        // Logits computation guarded by tok_pos == seq_len - 1
+        assert!(
+            prefill_body.contains("if tok_pos == seq_len - 1"),
+            "forward_prefill should only compute logits for the last token"
+        );
+        assert!(
+            prefill_body.contains("last_logits"),
+            "forward_prefill should use last_logits buffer"
+        );
+    }
+
+    #[test]
+    fn forward_prefill_q8_0_uses_q8_matmul() {
+        let config = tiny_q8_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        let prefill_start = code
+            .find("pub fn forward_prefill(")
+            .expect("forward_prefill not found");
+        let prefill_body = &code[prefill_start..];
+
+        // Q8_0 prefill should use q8_0 matmul variants
+        assert!(
+            prefill_body.contains("matmul_vec_q8_0_"),
+            "Q8_0 forward_prefill should use q8_0 matmul variants"
+        );
+        // Should not use plain f32 matmul for projections
+        assert!(
+            !prefill_body.contains("matmul_vec_64x64(&mut q"),
+            "Q8_0 forward_prefill should not call plain f32 matmul for q_proj"
+        );
     }
 }

--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -463,15 +463,15 @@ fn main() {{
     if let Some(ref cp) = load_cache_path {{ load_kv_cache(cp, &mut cache); }}
 
     let enc = tokenizer.encode(prompt.as_str(), false).expect("encode failed");
-    let tokens = enc.get_ids();
-    eprintln!("Prompt: {{}} tokens | temp={{}} top_k={{}} max_tokens={{}}", tokens.len(), temperature, top_k, max_tokens);
+    let prompt_tokens: Vec<u32> = enc.get_ids().to_vec();
+    eprintln!("Prompt: {{}} tokens | temp={{}} top_k={{}} max_tokens={{}}", prompt_tokens.len(), temperature, top_k, max_tokens);
 
-    // Prefill
+    // Prefill: process entire prompt in one batched pass, filling the KV cache
     let t0 = std::time::Instant::now();
     let mut rng_state: u64 = seed;
-    let mut next = 0u32;
-    for &tok in tokens {{ let mut l = model::forward(tok, &weights, &mut cache); next = sample(&mut l, temperature, top_k, top_p, &mut rng_state); }}
-    eprintln!("Prefill: {{:.1}} tok/s", tokens.len() as f64 / t0.elapsed().as_secs_f64());
+    let mut logits = model::forward_prefill(&prompt_tokens, &weights, &mut cache);
+    let mut next = sample(&mut logits, temperature, top_k, top_p, &mut rng_state);
+    eprintln!("Prefill: {{:.1}} tok/s", prompt_tokens.len() as f64 / t0.elapsed().as_secs_f64());
 
     // Generate
     if !quiet {{ print!("{{}}", prompt); }}
@@ -483,7 +483,7 @@ fn main() {{
         tokenizer.token_to_id("<|im_end|>"),
         tokenizer.token_to_id("<|eot_id|>"),
     ].iter().filter_map(|t| *t).collect();
-    let mut recent_tokens: Vec<u32> = tokens.to_vec();
+    let mut recent_tokens: Vec<u32> = prompt_tokens.clone();
     let mut gen_count = 0usize;
     for _ in 0..max_tokens {{
         if eos_tokens.contains(&next) {{ break; }}
@@ -520,11 +520,9 @@ fn main() {{
             }}
 
             let enc2 = tokenizer.encode(input, false).expect("encode failed");
-            let toks2 = enc2.get_ids();
-            for &tok in toks2 {{
-                let mut l = model::forward(tok, &weights, &mut cache);
-                next = sample(&mut l, temperature, top_k, top_p, &mut rng_state);
-            }}
+            let toks2: Vec<u32> = enc2.get_ids().to_vec();
+            let mut l2 = model::forward_prefill(&toks2, &weights, &mut cache);
+            next = sample(&mut l2, temperature, top_k, top_p, &mut rng_state);
             let t2 = std::time::Instant::now();
             let mut gen2 = 0usize;
             for _ in 0..max_tokens {{
@@ -782,15 +780,15 @@ fn main() {{
     if let Some(ref cp) = load_cache_path {{ load_kv_cache(cp, &mut cache); }}
 
     let enc = tokenizer.encode(prompt.as_str(), false).expect("encode failed");
-    let tokens = enc.get_ids();
-    eprintln!("Prompt: {{}} tokens | temp={{}} top_k={{}} max_tokens={{}}", tokens.len(), temperature, top_k, max_tokens);
+    let prompt_tokens: Vec<u32> = enc.get_ids().to_vec();
+    eprintln!("Prompt: {{}} tokens | temp={{}} top_k={{}} max_tokens={{}}", prompt_tokens.len(), temperature, top_k, max_tokens);
 
-    // Prefill
+    // Prefill: process entire prompt in one batched pass, filling the KV cache
     let t0 = std::time::Instant::now();
     let mut rng_state: u64 = seed;
-    let mut next = 0u32;
-    for &tok in tokens {{ let mut l = model::forward(tok, &weights, &mut cache); next = sample(&mut l, temperature, top_k, top_p, &mut rng_state); }}
-    eprintln!("Prefill: {{:.1}} tok/s", tokens.len() as f64 / t0.elapsed().as_secs_f64());
+    let mut logits = model::forward_prefill(&prompt_tokens, &weights, &mut cache);
+    let mut next = sample(&mut logits, temperature, top_k, top_p, &mut rng_state);
+    eprintln!("Prefill: {{:.1}} tok/s", prompt_tokens.len() as f64 / t0.elapsed().as_secs_f64());
 
     // Generate
     if !quiet {{ print!("{{}}", prompt); }}
@@ -802,7 +800,7 @@ fn main() {{
         tokenizer.token_to_id("<|im_end|>"),
         tokenizer.token_to_id("<|eot_id|>"),
     ].iter().filter_map(|t| *t).collect();
-    let mut recent_tokens: Vec<u32> = tokens.to_vec();
+    let mut recent_tokens: Vec<u32> = prompt_tokens.clone();
     let mut gen_count = 0usize;
     for _ in 0..max_tokens {{
         if eos_tokens.contains(&next) {{ break; }}
@@ -1065,6 +1063,106 @@ mod tests {
         assert!(
             lib_rs.contains("pub mod model;"),
             "lib.rs should re-export model module"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn main_uses_forward_prefill_for_prompt() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let dir = std::env::temp_dir().join("forgellm_test_prefill_main");
+        let _ = fs::remove_dir_all(&dir);
+        generate_project(&graph, &dir, "test-prefill", false).unwrap();
+
+        let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
+        assert!(
+            main.contains("model::forward_prefill("),
+            "main.rs should call forward_prefill for prompt processing"
+        );
+        // Prefill call should appear before the generation loop
+        let prefill_pos = main
+            .find("model::forward_prefill(")
+            .expect("forward_prefill call missing");
+        let gen_loop_pos = main
+            .find("for _ in 0..max_tokens")
+            .expect("generation loop missing");
+        assert!(
+            prefill_pos < gen_loop_pos,
+            "forward_prefill should be called before the generation loop"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn main_uses_prompt_tokens_vec_for_prefill() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let dir = std::env::temp_dir().join("forgellm_test_prefill_vec");
+        let _ = fs::remove_dir_all(&dir);
+        generate_project(&graph, &dir, "test-prefill-vec", false).unwrap();
+
+        let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
+        // The tokens should be collected into a Vec<u32> and passed to forward_prefill
+        assert!(
+            main.contains("let prompt_tokens: Vec<u32>"),
+            "main.rs should collect prompt tokens into Vec<u32>"
+        );
+        assert!(
+            main.contains("model::forward_prefill(&prompt_tokens,"),
+            "main.rs should pass &prompt_tokens to forward_prefill"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn embedded_main_uses_forward_prefill_for_prompt() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let dir = std::env::temp_dir().join("forgellm_test_embedded_prefill");
+        let _ = fs::remove_dir_all(&dir);
+        generate_project(&graph, &dir, "test-embedded-prefill", true).unwrap();
+
+        let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
+        assert!(
+            main.contains("model::forward_prefill("),
+            "embedded main.rs should call forward_prefill for prompt processing"
+        );
+        // forward_prefill should be called before the generation loop
+        let prefill_pos = main
+            .find("model::forward_prefill(")
+            .expect("forward_prefill call missing in embedded main");
+        let gen_loop_pos = main
+            .find("for _ in 0..max_tokens")
+            .expect("generation loop missing");
+        assert!(
+            prefill_pos < gen_loop_pos,
+            "forward_prefill should be called before the generation loop in embedded mode"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn interactive_mode_uses_forward_prefill() {
+        let config = tiny_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let dir = std::env::temp_dir().join("forgellm_test_interactive_prefill");
+        let _ = fs::remove_dir_all(&dir);
+        generate_project(&graph, &dir, "test-interactive-prefill", false).unwrap();
+
+        let main = fs::read_to_string(dir.join("src/main.rs")).unwrap();
+        // Interactive mode should also use forward_prefill for each user turn
+        let interactive_start = main
+            .find("Interactive mode")
+            .expect("interactive mode section missing");
+        let interactive_section = &main[interactive_start..];
+        assert!(
+            interactive_section.contains("forward_prefill("),
+            "interactive mode should use forward_prefill for user input"
         );
 
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Adds `forward_prefill(tokens: &[u32], weights: &Weights, cache: &mut KVCache) -> Vec<f32>` to generated model code
- Processes entire prompt in one pass before token generation begins, filling the KV cache sequentially
- Updated `generate_main()` and `generate_main_embedded()` to use `forward_prefill` for prompts, then `forward()` for each generated token
- Q8_0 path mirrors the F32 path

## Test plan
- [ ] Verify all 167 tests pass
- [ ] Generated main.rs calls `forward_prefill` before generation loop

Closes #126