### PR TITLE
perf: Q4_0 quantized matmul without dequantization

### DIFF
--- a/crates/forgellm-cli/src/main.rs
+++ b/crates/forgellm-cli/src/main.rs
@@ -1812,20 +1812,22 @@ fn cmd_export_weights_impl(
     let config = load_model_config(model_path)?;
 
     let is_q8 = config.dtype == DType::Q8_0;
+    let is_q4 = config.dtype == DType::Q4_0;
 
-    if is_q8 {
+    if is_q8 || is_q4 {
+        let quant_label = if is_q8 { "Q8_0" } else { "Q4_0" };
         if lora_path.is_some() {
             eprintln!(
-                "Warning: LoRA merging is not supported for Q8_0 quantized models. \
+                "Warning: LoRA merging is not supported for {quant_label} quantized models. \
                  The LoRA adapter will be ignored."
             );
         }
-        // Q8_0: keep projection weights as raw bytes, dequantize norm/embed to f32
+        // Quantized: keep projection weights as raw bytes, dequantize norm/embed to f32
         let (_gguf_file, weights) =
             load_from_file_mixed(model_path).with_context(|| "failed to load weights")?;
 
         eprintln!(
-            "Model: {} | {} layers | {} tensors | {:.1} MB (Q8_0 raw)",
+            "Model: {} | {} layers | {} tensors | {:.1} MB ({quant_label} raw)",
             config.architecture,
             config.num_layers,
             weights.len(),
@@ -1834,7 +1836,7 @@ fn cmd_export_weights_impl(
 
         let mut output_data: Vec<u8> = Vec::with_capacity(weights.memory_bytes());
 
-        // Write a tensor — for Q8_0 models: f32 tensors as f32 bytes, Q8_0 as raw bytes
+        // Write a tensor — for quantized models: f32 tensors as f32 bytes, raw quant as raw bytes
         let write_mixed = |data: &mut Vec<u8>, name: &str| {
             match weights.get(name) {
                 Some(WeightData::F32(v)) => {
@@ -1843,6 +1845,9 @@ fn cmd_export_weights_impl(
                     }
                 }
                 Some(WeightData::Q8_0Raw(b)) => {
+                    data.extend_from_slice(b);
+                }
+                Some(WeightData::Q4_0Raw(b)) => {
                     data.extend_from_slice(b);
                 }
                 None => {
@@ -1855,6 +1860,9 @@ fn cmd_export_weights_impl(
                                 }
                             }
                             Some(WeightData::Q8_0Raw(b)) => {
+                                data.extend_from_slice(b);
+                            }
+                            Some(WeightData::Q4_0Raw(b)) => {
                                 data.extend_from_slice(b);
                             }
                             None => panic!("neither lm_head nor embed_tokens found"),
@@ -1906,7 +1914,7 @@ fn cmd_export_weights_impl(
             .with_context(|| format!("failed to write {output_path}"))?;
 
         eprintln!(
-            "Exported {:.1} MB to {output_path} (Q8_0 raw bytes)",
+            "Exported {:.1} MB to {output_path} ({quant_label} raw bytes)",
             output_data.len() as f64 / 1e6,
         );
     } else {

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -1337,6 +1337,7 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
     let kv_size = num_kv_heads * head_dim;
 
     let is_q8 = config.dtype == DType::Q8_0;
+    let is_q4 = config.dtype == DType::Q4_0;
 
     writeln!(code)?;
     writeln!(code, "/// Process a prompt sequence and fill the KV cache.")?;
@@ -1422,6 +1423,25 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
             hidden = hidden,
             kv_size = kv_size
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
     } else {
         writeln!(
             code,
@@ -1490,6 +1510,13 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
             qk_size = qk_size,
             hidden = hidden
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
     } else {
         writeln!(
             code,
@@ -1523,6 +1550,19 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
             hidden = hidden,
             intermediate = intermediate
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
     } else {
         writeln!(
             code,
@@ -1542,6 +1582,13 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
         writeln!(
             code,
             "            matmul_vec_q8_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate,
+            hidden = hidden
+        )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "            matmul_vec_q4_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
             intermediate = intermediate,
             hidden = hidden
         )?;
@@ -1580,6 +1627,12 @@ fn emit_prefill_function(code: &mut String, config: &ModelConfig) -> Result<(), 
         writeln!(
             code,
             "                    out[r] = dot_q8_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
+        )?;
+    } else if is_q4 {
+        let lm_row_bytes = hidden.div_ceil(32) * 18;
+        writeln!(
+            code,
+            "                    out[r] = dot_q4_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
         )?;
     } else {
         writeln!(

--- a/crates/forgellm-codegen-cpu/src/emit.rs
+++ b/crates/forgellm-codegen-cpu/src/emit.rs
@@ -29,6 +29,10 @@ pub fn generate(graph: &Graph) -> Result<String, CodegenError> {
         emit_q8_0_kernel(&mut code)?;
         emit_specialized_q8_matmul_functions(&mut code, config)?;
     }
+    if config.dtype == DType::Q4_0 {
+        emit_q4_0_kernel(&mut code)?;
+        emit_specialized_q4_matmul_functions(&mut code, config)?;
+    }
     emit_specialized_matmul_functions(&mut code, config)?;
     emit_forward_function(&mut code, graph, config)?;
 
@@ -714,6 +718,158 @@ fn emit_specialized_q8_matmul_functions(
     Ok(())
 }
 
+/// Emit the Q4_0 dot-product helper. Also emits `f16_bits_to_f32` if Q8_0 did not already.
+fn emit_q4_0_kernel(code: &mut String) -> Result<(), CodegenError> {
+    code.push_str(
+        r#"
+// --- Q4_0 quantized dot product (no dequantization at load time) ---
+/// Convert IEEE 754 half-precision (f16) bit pattern to f32.
+#[inline]
+fn f16_bits_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exponent = ((bits >> 10) & 0x1F) as u32;
+    let mantissa = (bits & 0x3FF) as u32;
+    if exponent == 0 {
+        if mantissa == 0 { return f32::from_bits(sign << 31); }
+        let mut m = mantissa;
+        let mut e: i32 = -14;
+        while m & 0x400 == 0 { m <<= 1; e -= 1; }
+        m &= 0x3FF;
+        let f32_exp = ((e + 127) as u32) & 0xFF;
+        return f32::from_bits((sign << 31) | (f32_exp << 23) | (m << 13));
+    }
+    if exponent == 31 {
+        return f32::from_bits((sign << 31) | (0xFF << 23) | (mantissa << 13));
+    }
+    let f32_exp = (exponent as i32 - 15 + 127) as u32;
+    f32::from_bits((sign << 31) | (f32_exp << 23) | (mantissa << 13))
+}
+
+/// Dot product of f32 input against a Q4_0 weight row without prior dequantization.
+/// `weight_row`: raw Q4_0 bytes — layout: [2 bytes f16 scale][16 bytes 4-bit pairs] per block.
+/// Each byte packs two 4-bit values (offset by 8): lo = (byte & 0x0F) - 8, hi = (byte >> 4) - 8.
+/// Elements are interleaved: byte j holds element j and element j+16 within a block.
+/// `k`: number of input/weight elements.
+#[inline]
+fn dot_q4_0(input: &[f32], weight_row: &[u8], k: usize) -> f32 {
+    const BLOCK_SIZE: usize = 32;
+    const TYPE_SIZE: usize = 18; // 2 scale bytes + 16 data bytes
+    let num_blocks = k.div_ceil(BLOCK_SIZE);
+    let mut sum = 0.0f32;
+    for b in 0..num_blocks {
+        let bs = b * TYPE_SIZE;
+        let scale_bits = u16::from_le_bytes([weight_row[bs], weight_row[bs + 1]]);
+        let scale = f16_bits_to_f32(scale_bits);
+        for j in 0..16usize {
+            let byte = weight_row[bs + 2 + j];
+            let lo = (byte & 0x0F) as i32 - 8;
+            let hi = ((byte >> 4) & 0x0F) as i32 - 8;
+            let idx_lo = b * BLOCK_SIZE + j;
+            let idx_hi = b * BLOCK_SIZE + j + 16;
+            if idx_lo < k { sum += input[idx_lo] * (lo as f32 * scale); }
+            if idx_hi < k { sum += input[idx_hi] * (hi as f32 * scale); }
+        }
+    }
+    sum
+}
+
+"#,
+    );
+    Ok(())
+}
+
+/// Collect all unique (k, n) matmul shapes needed for Q4_0 projection weights.
+fn q4_matmul_shapes(config: &ModelConfig) -> Vec<(usize, usize)> {
+    matmul_shapes(config)
+}
+
+/// Emit shape-specialized Q4_0 matmul functions: `matmul_vec_q4_0_KxN`.
+/// These take `weight: &[u8]` (raw Q4_0 bytes) and call `dot_q4_0()` per output row.
+fn emit_specialized_q4_matmul_functions(
+    code: &mut String,
+    config: &ModelConfig,
+) -> Result<(), CodegenError> {
+    writeln!(
+        code,
+        "// --- Shape-specialized Q4_0 matmul functions (m=1, weight is &[u8]) ---"
+    )?;
+    writeln!(code)?;
+
+    let par_threshold = 4096;
+
+    for &(k, n) in &q4_matmul_shapes(config) {
+        // Byte size per row: ceil(k/32)*18
+        let row_bytes = k.div_ceil(32) * 18;
+        writeln!(
+            code,
+            "/// Q4_0 matmul: [1, {k}] x [{n}, {k}]^T -> [1, {n}] (weight stored as raw Q4_0 bytes)"
+        )?;
+        if n >= par_threshold {
+            writeln!(code, "#[inline]")?;
+            writeln!(
+                code,
+                "fn matmul_vec_q4_0_{k}x{n}(output: &mut [f32; {n}], input: &[f32; {k}], weight: &[u8]) {{"
+            )?;
+            writeln!(
+                code,
+                "    output.par_chunks_mut(256).enumerate().for_each(|(chunk_idx, out)| {{"
+            )?;
+            writeln!(code, "        let base = chunk_idx * 256;")?;
+            writeln!(code, "        for r in 0..out.len() {{")?;
+            writeln!(code, "            let j = base + r;")?;
+            writeln!(
+                code,
+                "            out[r] = dot_q4_0(&input[..], &weight[j*{row_bytes}..(j+1)*{row_bytes}], {k});"
+            )?;
+            writeln!(code, "        }}")?;
+            writeln!(code, "    }});")?;
+            writeln!(code, "}}")?;
+        } else {
+            writeln!(code, "#[inline]")?;
+            writeln!(
+                code,
+                "fn matmul_vec_q4_0_{k}x{n}(output: &mut [f32; {n}], input: &[f32; {k}], weight: &[u8]) {{"
+            )?;
+            let n_chunks = n / 4;
+            let n_remainder = n % 4;
+            if n_chunks > 0 {
+                writeln!(code, "    for chunk in 0..{n_chunks} {{")?;
+                writeln!(code, "        let j0 = chunk * 4;")?;
+                writeln!(
+                    code,
+                    "        output[j0]   = dot_q4_0(&input[..], &weight[j0*{row_bytes}..(j0+1)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+1] = dot_q4_0(&input[..], &weight[(j0+1)*{row_bytes}..(j0+2)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+2] = dot_q4_0(&input[..], &weight[(j0+2)*{row_bytes}..(j0+3)*{row_bytes}], {k});"
+                )?;
+                writeln!(
+                    code,
+                    "        output[j0+3] = dot_q4_0(&input[..], &weight[(j0+3)*{row_bytes}..(j0+4)*{row_bytes}], {k});"
+                )?;
+                writeln!(code, "    }}")?;
+            }
+            if n_remainder > 0 {
+                writeln!(code, "    let base = {n_chunks} * 4;")?;
+                for r in 0..n_remainder {
+                    writeln!(
+                        code,
+                        "    output[base+{r}] = dot_q4_0(&input[..], &weight[(base+{r})*{row_bytes}..(base+{r}+1)*{row_bytes}], {k});"
+                    )?;
+                }
+            }
+            writeln!(code, "}}")?;
+        }
+        writeln!(code)?;
+    }
+
+    Ok(())
+}
+
 fn emit_forward_function(
     code: &mut String,
     _graph: &Graph,
@@ -729,9 +885,18 @@ fn emit_forward_function(
     let kv_size = num_kv_heads * head_dim;
 
     let is_q8 = config.dtype == DType::Q8_0;
-    // Projection weight type: raw Q8_0 bytes for Q8_0 models, f32 otherwise
-    let proj_type = if is_q8 { "Vec<u8>" } else { "Vec<f32>" };
-    let lm_head_type = if is_q8 { "Vec<u8>" } else { "Vec<f32>" };
+    let is_q4 = config.dtype == DType::Q4_0;
+    // Projection weight type: raw bytes for quantized models, f32 otherwise
+    let proj_type = if is_q8 || is_q4 {
+        "Vec<u8>"
+    } else {
+        "Vec<f32>"
+    };
+    let lm_head_type = if is_q8 || is_q4 {
+        "Vec<u8>"
+    } else {
+        "Vec<f32>"
+    };
 
     writeln!(
         code,
@@ -923,6 +1088,25 @@ fn emit_forward_function(
             hidden = hidden,
             kv_size = kv_size
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{hidden}x{qk_size}(&mut q, &normed, &lw.q_proj);",
+            hidden = hidden,
+            qk_size = qk_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{hidden}x{kv_size}(&mut k, &normed, &lw.k_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{hidden}x{kv_size}(&mut v, &normed, &lw.v_proj);",
+            hidden = hidden,
+            kv_size = kv_size
+        )?;
     } else {
         writeln!(
             code,
@@ -991,6 +1175,13 @@ fn emit_forward_function(
             qk_size = qk_size,
             hidden = hidden
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{qk_size}x{hidden}(&mut attn_proj, &attn_out, &lw.o_proj);",
+            qk_size = qk_size,
+            hidden = hidden
+        )?;
     } else {
         writeln!(
             code,
@@ -1024,6 +1215,19 @@ fn emit_forward_function(
             hidden = hidden,
             intermediate = intermediate
         )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{hidden}x{intermediate}(&mut gate, &normed, &lw.gate_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{hidden}x{intermediate}(&mut up, &normed, &lw.up_proj);",
+            hidden = hidden,
+            intermediate = intermediate
+        )?;
     } else {
         writeln!(
             code,
@@ -1043,6 +1247,12 @@ fn emit_forward_function(
         writeln!(
             code,
             "        matmul_vec_q8_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
+            intermediate = intermediate, hidden = hidden
+        )?;
+    } else if is_q4 {
+        writeln!(
+            code,
+            "        matmul_vec_q4_0_{intermediate}x{hidden}(&mut ffn_out, &ffn_hidden, &lw.down_proj);",
             intermediate = intermediate, hidden = hidden
         )?;
     } else {
@@ -1087,6 +1297,12 @@ fn emit_forward_function(
         writeln!(
             code,
             "            out[r] = dot_q8_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
+        )?;
+    } else if is_q4 {
+        let lm_row_bytes = hidden.div_ceil(32) * 18;
+        writeln!(
+            code,
+            "            out[r] = dot_q4_0(&normed[..], &weights.lm_head[j*{lm_row_bytes}..(j+1)*{lm_row_bytes}], {hidden});"
         )?;
     } else {
         writeln!(
@@ -1508,6 +1724,131 @@ mod tests {
         assert!(
             !code.contains("matmul_vec_q8_0_"),
             "non-Q8_0 model should not emit Q8_0 matmul variants"
+        );
+        // Should use regular Vec<f32> for all weight fields
+        assert!(code.contains("pub q_proj: Vec<f32>"));
+        assert!(code.contains("pub lm_head: Vec<f32>"));
+    }
+
+    fn tiny_q4_config() -> ModelConfig {
+        ModelConfig {
+            architecture: Architecture::Llama,
+            hidden_size: 64,
+            intermediate_size: 128,
+            num_layers: 2,
+            num_attention_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 16,
+            vocab_size: 256,
+            max_seq_len: 64,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            dtype: DType::Q4_0,
+        }
+    }
+
+    #[test]
+    fn q4_0_model_generates_vec_u8_fields() {
+        let config = tiny_q4_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Projection weights should be Vec<u8>
+        assert!(
+            code.contains("pub q_proj: Vec<u8>"),
+            "q_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub k_proj: Vec<u8>"),
+            "k_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub v_proj: Vec<u8>"),
+            "v_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub o_proj: Vec<u8>"),
+            "o_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub gate_proj: Vec<u8>"),
+            "gate_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub up_proj: Vec<u8>"),
+            "up_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub down_proj: Vec<u8>"),
+            "down_proj should be Vec<u8> for Q4_0 model"
+        );
+        assert!(
+            code.contains("pub lm_head: Vec<u8>"),
+            "lm_head should be Vec<u8> for Q4_0 model"
+        );
+        // Norm and embedding weights are always f32
+        assert!(
+            code.contains("pub attn_norm: Vec<f32>"),
+            "attn_norm should remain Vec<f32>"
+        );
+        assert!(
+            code.contains("pub embed_tokens: Vec<f32>"),
+            "embed_tokens should remain Vec<f32>"
+        );
+        assert!(
+            code.contains("pub final_norm: Vec<f32>"),
+            "final_norm should remain Vec<f32>"
+        );
+    }
+
+    #[test]
+    fn q4_0_model_generates_dot_q4_0_function() {
+        let config = tiny_q4_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        assert!(
+            code.contains("fn dot_q4_0("),
+            "Q4_0 model should emit dot_q4_0 function"
+        );
+        assert!(
+            code.contains("fn f16_bits_to_f32("),
+            "Q4_0 model should emit f16_bits_to_f32 helper"
+        );
+    }
+
+    #[test]
+    fn q4_0_model_calls_q4_matmul_in_forward() {
+        let config = tiny_q4_config();
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Forward function should use q4_0 matmul variants
+        assert!(
+            code.contains("matmul_vec_q4_0_"),
+            "Q4_0 model should call matmul_vec_q4_0_* variants"
+        );
+        // Should not use regular f32 matmul for projections in forward
+        assert!(
+            !code.contains("matmul_vec_64x64(&mut q"),
+            "Q4_0 model should not call f32 matmul for q_proj"
+        );
+    }
+
+    #[test]
+    fn f32_model_does_not_generate_q4_0_kernels() {
+        let config = tiny_config(); // F16 dtype
+        let graph = graph_builder::build_graph(&config).unwrap();
+        let code = generate(&graph).unwrap();
+
+        // Non-Q4_0 models should not have q4_0 functions
+        assert!(
+            !code.contains("fn dot_q4_0("),
+            "non-Q4_0 model should not emit dot_q4_0"
+        );
+        assert!(
+            !code.contains("matmul_vec_q4_0_"),
+            "non-Q4_0 model should not emit Q4_0 matmul variants"
         );
         // Should use regular Vec<f32> for all weight fields
         assert!(code.contains("pub q_proj: Vec<f32>"));

--- a/crates/forgellm-codegen-cpu/src/project.rs
+++ b/crates/forgellm-codegen-cpu/src/project.rs
@@ -157,23 +157,43 @@ fn generate_main(config: &ModelConfig) -> String {
     let qk_size = num_heads * head_dim;
     let kv_size = num_kv_heads * head_dim;
     let is_q8 = config.dtype == DType::Q8_0;
+    let is_q4 = config.dtype == DType::Q4_0;
 
     // Pre-compute Q8_0 row byte sizes (ceil(numel/32)*34 per row)
     let q8_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 34 };
+    // Pre-compute Q4_0 row byte sizes (ceil(numel/32)*18 per row)
+    let q4_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 18 };
 
-    // Byte sizes for Q8_0 weight tensors
-    let qp_bytes = qk_size * q8_row_bytes(hidden);
-    let kp_bytes = kv_size * q8_row_bytes(hidden);
-    let vp_bytes = kv_size * q8_row_bytes(hidden);
-    let op_bytes = hidden * q8_row_bytes(qk_size);
-    let gp_bytes = inter * q8_row_bytes(hidden);
-    let up_bytes = inter * q8_row_bytes(hidden);
-    let dp_bytes = hidden * q8_row_bytes(inter);
-    let lmh_bytes = vocab * q8_row_bytes(hidden);
+    // Byte sizes for quantized weight tensors (Q8_0 or Q4_0)
+    let (qp_bytes, kp_bytes, vp_bytes, op_bytes, gp_bytes, up_bytes, dp_bytes, lmh_bytes) = if is_q8
+    {
+        (
+            qk_size * q8_row_bytes(hidden),
+            kv_size * q8_row_bytes(hidden),
+            kv_size * q8_row_bytes(hidden),
+            hidden * q8_row_bytes(qk_size),
+            inter * q8_row_bytes(hidden),
+            inter * q8_row_bytes(hidden),
+            hidden * q8_row_bytes(inter),
+            vocab * q8_row_bytes(hidden),
+        )
+    } else {
+        // Q4_0 sizes (also used as placeholder for non-quantized, unused)
+        (
+            qk_size * q4_row_bytes(hidden),
+            kv_size * q4_row_bytes(hidden),
+            kv_size * q4_row_bytes(hidden),
+            hidden * q4_row_bytes(qk_size),
+            inter * q4_row_bytes(hidden),
+            inter * q4_row_bytes(hidden),
+            hidden * q4_row_bytes(inter),
+            vocab * q4_row_bytes(hidden),
+        )
+    };
 
-    let weight_loading_code = if is_q8 {
-        // Q8_0: load raw bytes; norm/embed are still f32
-        r##"fn load_weights_q8(path: &str) -> Vec<u8> {
+    let weight_loading_code = if is_q8 || is_q4 {
+        // Quantized: load raw bytes; norm/embed are still f32
+        r##"fn load_weights_raw(path: &str) -> Vec<u8> {
     let file = std::fs::File::open(path).expect("failed to open weights");
     let mmap = unsafe { memmap2::Mmap::map(&file) }.expect("failed to mmap weights");
     mmap.to_vec()
@@ -201,10 +221,11 @@ fn generate_main(config: &ModelConfig) -> String {
         .to_string()
     };
 
-    let weight_slice_code = if is_q8 {
-        // Q8_0: byte offsets for projection weights, f32 element offsets for norm/embed
+    let weight_slice_code = if is_q8 || is_q4 {
+        // Quantized: byte offsets for projection weights, f32 element offsets for norm/embed
+        let quant_label = if is_q8 { "Q8_0" } else { "Q4_0" };
         format!(
-            r##"    let w = load_weights_q8(weights_path);
+            r##"    let w = load_weights_raw(weights_path);
     let mut boff = 0usize;  // byte offset into raw buffer
 
     // embed_tokens: f32, interpreted from raw bytes
@@ -233,7 +254,7 @@ fn generate_main(config: &ModelConfig) -> String {
             v
         }};
         boff += an_bytes;
-        // Projection weights: Q8_0 raw bytes
+        // Projection weights: {quant_label} raw bytes
         let qp = w[boff..boff+{qp_bytes}].to_vec(); boff += {qp_bytes};
         let kp = w[boff..boff+{kp_bytes}].to_vec(); boff += {kp_bytes};
         let vp = w[boff..boff+{vp_bytes}].to_vec(); boff += {vp_bytes};
@@ -267,7 +288,7 @@ fn generate_main(config: &ModelConfig) -> String {
         v
     }};
     boff += fnorm_bytes;
-    // lm_head: Q8_0 raw bytes
+    // lm_head: {quant_label} raw bytes
     let lmh = w[boff..boff+{lmh_bytes}].to_vec();
     let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
         )
@@ -559,19 +580,37 @@ fn generate_main_embedded(config: &ModelConfig) -> String {
     let qk_size = num_heads * head_dim;
     let kv_size = num_kv_heads * head_dim;
     let is_q8 = config.dtype == DType::Q8_0;
+    let is_q4 = config.dtype == DType::Q4_0;
 
     let q8_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 34 };
-    let qp_bytes = qk_size * q8_row_bytes(hidden);
-    let kp_bytes = kv_size * q8_row_bytes(hidden);
-    let vp_bytes = kv_size * q8_row_bytes(hidden);
-    let op_bytes = hidden * q8_row_bytes(qk_size);
-    let gp_bytes = inter * q8_row_bytes(hidden);
-    let up_bytes = inter * q8_row_bytes(hidden);
-    let dp_bytes = hidden * q8_row_bytes(inter);
-    let lmh_bytes = vocab * q8_row_bytes(hidden);
+    let q4_row_bytes = |numel: usize| -> usize { numel.div_ceil(32) * 18 };
+    let (qp_bytes, kp_bytes, vp_bytes, op_bytes, gp_bytes, up_bytes, dp_bytes, lmh_bytes) = if is_q8
+    {
+        (
+            qk_size * q8_row_bytes(hidden),
+            kv_size * q8_row_bytes(hidden),
+            kv_size * q8_row_bytes(hidden),
+            hidden * q8_row_bytes(qk_size),
+            inter * q8_row_bytes(hidden),
+            inter * q8_row_bytes(hidden),
+            hidden * q8_row_bytes(inter),
+            vocab * q8_row_bytes(hidden),
+        )
+    } else {
+        (
+            qk_size * q4_row_bytes(hidden),
+            kv_size * q4_row_bytes(hidden),
+            kv_size * q4_row_bytes(hidden),
+            hidden * q4_row_bytes(qk_size),
+            inter * q4_row_bytes(hidden),
+            inter * q4_row_bytes(hidden),
+            hidden * q4_row_bytes(inter),
+            vocab * q4_row_bytes(hidden),
+        )
+    };
 
-    let bytes_helper = if is_q8 {
-        // For Q8_0, we only need the bytes_to_f32 helper for norm/embed extraction
+    let bytes_helper = if is_q8 || is_q4 {
+        // For quantized models, we only need the bytes_to_f32 helper for norm/embed extraction
         r##"fn bytes_to_f32_slice(bytes: &[u8]) -> Vec<f32> {
     let n = bytes.len() / 4;
     let mut out = Vec::<f32>::with_capacity(n);
@@ -597,7 +636,9 @@ fn generate_main_embedded(config: &ModelConfig) -> String {
         .to_string()
     };
 
-    let weight_slice_code_embedded = if is_q8 {
+    let quant_label = if is_q8 { "Q8_0" } else { "Q4_0" };
+
+    let weight_slice_code_embedded = if is_q8 || is_q4 {
         format!(
             r##"    let w: &[u8] = WEIGHTS_BYTES;
     let mut boff = 0usize;
@@ -609,6 +650,7 @@ fn generate_main_embedded(config: &ModelConfig) -> String {
     for _ in 0..{num_layers} {{
         let an_bytes = {hidden} * 4;
         let an = bytes_to_f32_slice(&w[boff..boff+an_bytes]); boff += an_bytes;
+        // Projection weights: {quant_label} raw bytes
         let qp = w[boff..boff+{qp_bytes}].to_vec(); boff += {qp_bytes};
         let kp = w[boff..boff+{kp_bytes}].to_vec(); boff += {kp_bytes};
         let vp = w[boff..boff+{vp_bytes}].to_vec(); boff += {vp_bytes};
@@ -622,6 +664,7 @@ fn generate_main_embedded(config: &ModelConfig) -> String {
     }}
     let fnorm_bytes = {hidden} * 4;
     let fnorm = bytes_to_f32_slice(&w[boff..boff+fnorm_bytes]); boff += fnorm_bytes;
+    // lm_head: {quant_label} raw bytes
     let lmh = w[boff..boff+{lmh_bytes}].to_vec();
     let weights = model::Weights {{ embed_tokens: embed, layers, final_norm: fnorm, lm_head: lmh }};"##
         )

--- a/crates/forgellm-frontend/src/weight_loader.rs
+++ b/crates/forgellm-frontend/src/weight_loader.rs
@@ -9,13 +9,15 @@ use std::path::Path;
 
 use crate::gguf::{self, GGMLType, GGUFFile, GGUFTensorInfo};
 
-/// Raw weight data — either f32 (dequantized) or Q8_0 raw bytes.
+/// Raw weight data — either f32 (dequantized), Q8_0 raw bytes, or Q4_0 raw bytes.
 #[derive(Debug, Clone)]
 pub enum WeightData {
     /// Fully dequantized f32 tensor.
     F32(Vec<f32>),
     /// Raw Q8_0 bytes: N_blocks * 34 bytes each block = [2 bytes f16 scale][32 bytes int8].
     Q8_0Raw(Vec<u8>),
+    /// Raw Q4_0 bytes: N_blocks * 18 bytes each block = [2 bytes f16 scale][16 bytes 4-bit pairs].
+    Q4_0Raw(Vec<u8>),
 }
 
 /// Model weights with mixed storage: Q8_0 kept as raw bytes, others as f32.
@@ -41,6 +43,14 @@ impl ModelWeightsRaw {
         }
     }
 
+    /// Get a Q4_0 raw byte tensor by name.
+    pub fn get_q4_raw(&self, name: &str) -> Option<&[u8]> {
+        match self.tensors.get(name) {
+            Some(WeightData::Q4_0Raw(v)) => Some(v.as_slice()),
+            _ => None,
+        }
+    }
+
     /// Number of loaded tensors.
     pub fn len(&self) -> usize {
         self.tensors.len()
@@ -58,6 +68,7 @@ impl ModelWeightsRaw {
             .map(|v| match v {
                 WeightData::F32(f) => f.len() * 4,
                 WeightData::Q8_0Raw(b) => b.len(),
+                WeightData::Q4_0Raw(b) => b.len(),
             })
             .sum()
     }
@@ -70,6 +81,7 @@ impl ModelWeightsRaw {
 
 /// Load all tensors from a GGUF file with mixed storage:
 /// - Q8_0 tensors are kept as raw bytes (`WeightData::Q8_0Raw`)
+/// - Q4_0 tensors are kept as raw bytes (`WeightData::Q4_0Raw`)
 /// - All other tensor types are dequantized to f32 (`WeightData::F32`)
 pub fn load_from_file_mixed(
     path: impl AsRef<std::path::Path>,
@@ -101,6 +113,8 @@ pub fn load_from_file_mixed(
 
         let weight_data = if tensor_info.ggml_type == crate::gguf::GGMLType::Q8_0 {
             WeightData::Q8_0Raw(raw.to_vec())
+        } else if tensor_info.ggml_type == crate::gguf::GGMLType::Q4_0 {
+            WeightData::Q4_0Raw(raw.to_vec())
         } else {
             let f32_data = dequantize(raw, tensor_info.ggml_type, numel)?;
             WeightData::F32(f32_data)
@@ -906,5 +920,45 @@ mod tests {
         assert!(raw.get_q8_raw("norm.weight").is_none());
         // Memory bytes: 64*4 + 68 = 256 + 68 = 324
         assert_eq!(raw.memory_bytes(), 64 * 4 + 68);
+    }
+
+    #[test]
+    fn model_weights_raw_q4_0_accessor() {
+        let mut tensors = HashMap::new();
+        tensors.insert("norm.weight".to_string(), WeightData::F32(vec![1.0f32; 64]));
+        // Q4_0: 2 blocks * 18 bytes each = 36 bytes (64 elements / 32 per block * 18)
+        tensors.insert(
+            "q_proj.weight".to_string(),
+            WeightData::Q4_0Raw(vec![0u8; 36]),
+        );
+        let raw = ModelWeightsRaw { tensors };
+
+        assert_eq!(raw.len(), 2);
+        assert!(raw.get_q4_raw("q_proj.weight").is_some());
+        assert_eq!(raw.get_q4_raw("q_proj.weight").unwrap().len(), 36);
+        // Cross-type accessors should return None
+        assert!(raw.get_f32("q_proj.weight").is_none());
+        assert!(raw.get_q8_raw("q_proj.weight").is_none());
+        assert!(raw.get_q4_raw("norm.weight").is_none());
+        // Memory bytes: 64*4 + 36 = 256 + 36 = 292
+        assert_eq!(raw.memory_bytes(), 64 * 4 + 36);
+    }
+
+    #[test]
+    fn weight_data_q4_0_raw_stored_correctly() {
+        // Build a minimal Q4_0 block (18 bytes)
+        let scale_f16: u16 = 0x3C00; // 1.0 in f16
+        let mut block = Vec::new();
+        block.extend_from_slice(&scale_f16.to_le_bytes()); // 2 bytes scale
+        block.extend(std::iter::repeat_n(0x88u8, 16)); // 16 bytes: all nibbles = 8 → 8-8=0
+
+        let wd = WeightData::Q4_0Raw(block.clone());
+        match &wd {
+            WeightData::Q4_0Raw(v) => {
+                assert_eq!(v.len(), 18);
+                assert_eq!(&v[..], &block[..]);
+            }
+            _ => panic!("expected Q4_0Raw variant"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `dot_q4_0()` kernel: 18-byte blocks (f16 scale + 16 packed nibbles, offset-8 decoding)
- Adds `matmul_vec_q4_0_KxN` variants for all projection shapes (parallel for N ≥ 4096, sequential 4-way unrolled for smaller)
- Models with `DType::Q4_0` use `Vec<u8>` weight fields and call Q4_0 kernels directly — no float conversion at load time
- `WeightData::Q4_0Raw` variant in `weight_loader.rs`; `load_from_file_mixed()` keeps Q4_0 bytes raw
- Mirrors Q8_0 pattern throughout

## Test plan
- [ ] Verify 162 tests pass (6 new)
- [ ] Q4_0 models generate correctly typed weight fields

Closes #127