### PR TITLE
feat: Python bindings via PyO3 (pip install forgellm)

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,76 @@
+name: Publish Python Wheels
+
+# Trigger on version tags (e.g. v0.4.1) or manual dispatch.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-wheels:
+    name: Build wheels (${{ matrix.os }} / ${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86-64: use manylinux for broad compatibility
+          - os: ubuntu-latest
+            target: x86_64
+            manylinux: auto
+          # macOS Intel
+          - os: macos-13
+            target: x86_64
+            manylinux: ''
+          # macOS Apple Silicon
+          - os: macos-14
+            target: aarch64
+            manylinux: ''
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build wheels via maturin
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: crates/forgellm-python
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --out dist --strip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: crates/forgellm-python/dist/*.whl
+
+  publish:
+    name: Publish to PyPI
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    # Only publish when triggered by a tag push, not workflow_dispatch
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/forgellm
+    permissions:
+      id-token: write  # for OIDC-based trusted publishing
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -497,6 +497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "forgellm-python"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "forgellm-codegen-cpu",
+ "forgellm-frontend",
+ "forgellm-optimizer",
+ "forgellm-runtime",
+ "pyo3",
+]
+
+[[package]]
 name = "forgellm-runtime"
 version = "0.4.0"
 dependencies = [
@@ -532,6 +544,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -547,6 +565,15 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is-terminal"
@@ -618,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -760,6 +805,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +905,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -909,6 +1046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1116,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1069,6 +1221,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -1242,6 +1400,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/forgellm-codegen-gpu",
     "crates/forgellm-runtime",
     "crates/forgellm-cli",
+    "crates/forgellm-python",
 ]
 resolver = "2"
 

--- a/crates/forgellm-python/Cargo.toml
+++ b/crates/forgellm-python/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "forgellm-python"
+description = "Python bindings for ForgeLLM — AOT compiler for small LLMs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+name = "forgellm"
+# cdylib = Python extension (.so / .pyd); rlib for optional Rust consumers.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+forgellm-frontend  = { workspace = true }
+forgellm-optimizer = { workspace = true }
+forgellm-codegen-cpu = { workspace = true }
+forgellm-runtime   = { workspace = true }
+pyo3 = { version = "0.21", features = ["extension-module"] }
+anyhow = { workspace = true }

--- a/crates/forgellm-python/pyproject.toml
+++ b/crates/forgellm-python/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "forgellm"
+requires-python = ">=3.8"
+description = "Python bindings for ForgeLLM — AOT compiler for small LLMs"
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[tool.maturin]
+# The Rust crate to build (relative to pyproject.toml)
+manifest-path = "Cargo.toml"
+# Module name matches the #[pymodule] name in src/lib.rs
+module-name = "forgellm"

--- a/crates/forgellm-python/src/lib.rs
+++ b/crates/forgellm-python/src/lib.rs
@@ -1,0 +1,427 @@
+//! Python bindings for ForgeLLM via PyO3.
+//!
+//! Exposes two top-level APIs:
+//!
+//! ```python
+//! import forgellm
+//!
+//! # AOT compilation: model + weights → standalone Rust project
+//! forgellm.compile('smollm2.gguf', output_dir='./compiled', target='cpu')
+//!
+//! # Interpreter inference: load once, call generate() repeatedly
+//! model = forgellm.Model('smollm2.gguf')
+//! print(model.generate('The meaning of life is', max_tokens=64))
+//! ```
+
+use std::path::Path;
+
+use anyhow::{bail, Context};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+use forgellm_frontend::{gguf, graph_builder, ir::*, weight_loader};
+use forgellm_runtime::{interpreter, kv_cache::KVCache, sampling, tokenizer::Tokenizer};
+
+// ─── Error conversion ────────────────────────────────────────────────────────
+
+fn to_py(e: anyhow::Error) -> PyErr {
+    PyRuntimeError::new_err(format!("{e:#}"))
+}
+
+// ─── GGUF config extraction ───────────────────────────────────────────────────
+
+/// Extract a `ModelConfig` from a GGUF file by reading its metadata section.
+///
+/// This mirrors the logic in `forgellm-cli`'s `load_model_config` so the
+/// Python bindings do not depend on the CLI crate.
+fn config_from_gguf(path: &str) -> anyhow::Result<ModelConfig> {
+    let data = std::fs::read(path).with_context(|| format!("failed to read '{path}'"))?;
+    let g = gguf::parse(std::io::Cursor::new(&data))
+        .with_context(|| format!("failed to parse GGUF file '{path}'"))?;
+
+    let arch_name = g.architecture().unwrap_or("unknown").to_string();
+    let p = &arch_name; // metadata prefix
+
+    let hidden = g
+        .get_u32(&format!("{p}.embedding_length"))
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let num_layers = g
+        .get_u32(&format!("{p}.block_count"))
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let num_heads = g
+        .get_u32(&format!("{p}.attention.head_count"))
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let num_kv_heads = g
+        .get_u32(&format!("{p}.attention.head_count_kv"))
+        .map(|v| v as usize)
+        .unwrap_or(num_heads);
+
+    if hidden == 0 || num_layers == 0 || num_heads == 0 {
+        bail!("could not extract model dimensions from GGUF metadata in '{path}'");
+    }
+
+    let head_dim = hidden / num_heads;
+    let intermediate = g
+        .get_u32(&format!("{p}.feed_forward_length"))
+        .map(|v| v as usize)
+        .unwrap_or(hidden * 4);
+    let vocab_size = g
+        .get_array_len("tokenizer.ggml.tokens")
+        .or_else(|| g.get_u64(&format!("{p}.vocab_size")).map(|v| v as usize))
+        .unwrap_or(32000);
+    let max_seq_len = g
+        .get_u64(&format!("{p}.context_length"))
+        .map(|v| v as usize)
+        .unwrap_or(2048);
+    let rms_norm_eps = g
+        .get_f32(&format!("{p}.attention.layer_norm_rms_epsilon"))
+        .unwrap_or(1e-5);
+    let rope_theta = g.get_f32(&format!("{p}.rope.freq_base")).unwrap_or(10000.0);
+
+    let architecture = match arch_name.as_str() {
+        "llama" => Architecture::Llama,
+        "qwen2" => Architecture::Qwen2,
+        "mistral" => Architecture::Mistral,
+        "phi3" | "phi" => Architecture::Phi3,
+        "gemma" | "gemma2" => Architecture::Gemma,
+        other => bail!("unsupported GGUF architecture '{other}'"),
+    };
+
+    let sliding_window_size = g
+        .get_u32(&format!("{p}.attention.sliding_window"))
+        .map(|v| v as usize);
+    let qkv_bias = matches!(architecture, Architecture::Qwen2);
+
+    Ok(ModelConfig {
+        architecture,
+        hidden_size: hidden,
+        intermediate_size: intermediate,
+        num_layers,
+        num_attention_heads: num_heads,
+        num_kv_heads,
+        head_dim,
+        vocab_size,
+        max_seq_len,
+        rms_norm_eps,
+        rope_theta,
+        dtype: DType::F16,
+        sliding_window_size,
+        qkv_bias,
+    })
+}
+
+// ─── Tokenizer auto-detection ─────────────────────────────────────────────────
+
+/// Search for `tokenizer.json` near the model file.
+///
+/// Tries the model's directory, then its parent, following the same convention
+/// as the `forge run` CLI command.
+fn find_tokenizer(model_path: &str) -> Option<String> {
+    let model = Path::new(model_path);
+    if let Some(dir) = model.parent() {
+        let candidate = dir.join("tokenizer.json");
+        if candidate.exists() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+        if let Some(parent) = dir.parent() {
+            let candidate = parent.join("tokenizer.json");
+            if candidate.exists() {
+                return Some(candidate.to_string_lossy().into_owned());
+            }
+        }
+    }
+    None
+}
+
+// ─── compile() ───────────────────────────────────────────────────────────────
+
+/// Compile a GGUF model into a standalone Rust project.
+///
+/// Runs the full AOT pipeline (parse → IR → optimize → codegen) and writes
+/// a self-contained Rust project to *output_dir*.  The resulting project can
+/// be built with ``cargo build --release`` to produce a zero-dependency binary.
+///
+/// Parameters
+/// ----------
+/// model_path : str
+///     Path to a GGUF model file.
+/// output_dir : str
+///     Directory where the generated Rust project will be written.
+///     Created if it does not exist.
+/// target : str, optional
+///     Backend target. Currently only ``"cpu"`` is supported (default).
+///
+/// Raises
+/// ------
+/// RuntimeError
+///     If the model cannot be loaded, the architecture is unsupported, or
+///     code generation fails.
+///
+/// Examples
+/// --------
+/// >>> import forgellm
+/// >>> forgellm.compile('smollm2-135m.gguf', output_dir='./compiled')
+#[pyfunction]
+#[pyo3(signature = (model_path, output_dir, target = "cpu"))]
+fn compile(model_path: &str, output_dir: &str, target: &str) -> PyResult<()> {
+    if target != "cpu" {
+        return Err(to_py(anyhow::anyhow!(
+            "unsupported target '{target}'; only 'cpu' is supported"
+        )));
+    }
+
+    let config = config_from_gguf(model_path).map_err(to_py)?;
+
+    let graph = graph_builder::build_graph(&config).map_err(|e| to_py(anyhow::anyhow!("{e}")))?;
+
+    let optimized = forgellm_optimizer::optimize(&graph);
+
+    let out = Path::new(output_dir);
+    std::fs::create_dir_all(out)
+        .map_err(|e| to_py(anyhow::anyhow!("failed to create '{output_dir}': {e}")))?;
+
+    let model_name = out
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "model".to_string());
+
+    forgellm_codegen_cpu::generate_project(&optimized, out, &model_name, false)
+        .map_err(|e| to_py(anyhow::anyhow!("{e}")))?;
+
+    Ok(())
+}
+
+// ─── Model class ─────────────────────────────────────────────────────────────
+
+/// Interpreter-backed LLM loaded from a GGUF file.
+///
+/// Loads the model weights into memory and provides a ``generate()`` method
+/// for text generation using the ForgeLLM interpreter (not an AOT binary).
+/// The interpreter is convenient for prototyping and correctness testing;
+/// for production throughput, compile with :func:`forgellm.compile` instead.
+///
+/// Parameters
+/// ----------
+/// model_path : str
+///     Path to a GGUF model file.
+/// tokenizer_path : str or None, optional
+///     Path to ``tokenizer.json``.  If *None*, the file is auto-detected in
+///     the same directory as the model (or its parent).
+///
+/// Attributes
+/// ----------
+/// architecture : str
+///     Architecture name (e.g. ``"Llama"``, ``"Mistral"``).
+/// num_layers : int
+///     Number of transformer layers.
+/// hidden_size : int
+///     Hidden state dimensionality.
+/// vocab_size : int
+///     Vocabulary size.
+///
+/// Examples
+/// --------
+/// >>> import forgellm
+/// >>> model = forgellm.Model('smollm2-135m.gguf')
+/// >>> output = model.generate('The meaning of life is', max_tokens=64)
+/// >>> print(output)
+#[pyclass]
+pub struct Model {
+    graph: forgellm_frontend::ir::Graph,
+    weights: forgellm_frontend::weight_loader::ModelWeights,
+    tokenizer: Tokenizer,
+    config: ModelConfig,
+}
+
+#[pymethods]
+impl Model {
+    #[new]
+    #[pyo3(signature = (model_path, tokenizer_path = None))]
+    fn new(model_path: &str, tokenizer_path: Option<&str>) -> PyResult<Self> {
+        // Load model configuration from GGUF metadata
+        let config = config_from_gguf(model_path).map_err(to_py)?;
+
+        // Build computation graph from config
+        let graph =
+            graph_builder::build_graph(&config).map_err(|e| to_py(anyhow::anyhow!("{e}")))?;
+
+        // Load and dequantize weights
+        let (_gguf_file, weights) = weight_loader::load_from_file(model_path).map_err(|e| {
+            to_py(anyhow::anyhow!(
+                "failed to load weights from '{model_path}': {e}"
+            ))
+        })?;
+
+        // Resolve tokenizer path
+        let tok_path = if let Some(p) = tokenizer_path {
+            p.to_string()
+        } else {
+            find_tokenizer(model_path).ok_or_else(|| {
+                to_py(anyhow::anyhow!(
+                    "tokenizer.json not found near '{}'; \
+                     pass tokenizer_path= explicitly or place tokenizer.json \
+                     in the same directory as the model",
+                    model_path
+                ))
+            })?
+        };
+
+        let tokenizer = Tokenizer::from_file(&tok_path).map_err(|e| {
+            to_py(anyhow::anyhow!(
+                "failed to load tokenizer from '{}': {e}",
+                tok_path
+            ))
+        })?;
+
+        Ok(Self {
+            graph,
+            weights,
+            tokenizer,
+            config,
+        })
+    }
+
+    /// Generate text continuation for *prompt*.
+    ///
+    /// Parameters
+    /// ----------
+    /// prompt : str
+    ///     Input text.
+    /// max_tokens : int, optional
+    ///     Maximum number of new tokens to generate (default: ``64``).
+    ///     The actual count may be less if an EOS token is produced.
+    /// temperature : float, optional
+    ///     Sampling temperature (default: ``0.7``).  Pass ``0.0`` for
+    ///     deterministic greedy decoding.
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///     Generated text (the prompt is not included in the output).
+    ///
+    /// Raises
+    /// ------
+    /// RuntimeError
+    ///     If the prompt exceeds the model's context length, or if encoding
+    ///     or decoding fails.
+    #[pyo3(signature = (prompt, max_tokens = 64, temperature = 0.7))]
+    fn generate(&self, prompt: &str, max_tokens: usize, temperature: f32) -> PyResult<String> {
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| to_py(anyhow::anyhow!("failed to encode prompt: {e}")))?;
+
+        if prompt_tokens.is_empty() {
+            return Ok(String::new());
+        }
+
+        let max_ctx = self.config.max_seq_len;
+        if prompt_tokens.len() >= max_ctx {
+            return Err(to_py(anyhow::anyhow!(
+                "prompt is {} tokens but model context is {}; shorten the prompt",
+                prompt_tokens.len(),
+                max_ctx,
+            )));
+        }
+
+        let sampling_config = if temperature == 0.0 {
+            sampling::SamplingConfig::greedy()
+        } else {
+            sampling::SamplingConfig {
+                temperature,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+            }
+        };
+
+        // Fresh KV cache for this generation (stateless)
+        let mut cache = KVCache::with_capacity(
+            self.config.num_layers,
+            self.config.num_kv_heads,
+            self.config.head_dim,
+            max_ctx,
+        );
+
+        // Prefill: process the prompt tokens
+        let mut next_token = 0u32;
+        for (pos, &token_id) in prompt_tokens.iter().enumerate() {
+            let logits =
+                interpreter::forward(token_id, pos, &self.graph, &self.weights, &mut cache);
+            cache.advance();
+            next_token = sampling::sample(&logits, &sampling_config, pos as u64);
+        }
+
+        // Generate up to max_tokens new tokens
+        let budget = max_tokens.min(max_ctx - prompt_tokens.len());
+        let stop_ids = self.tokenizer.stop_token_ids();
+        let mut generated: Vec<u32> = Vec::with_capacity(budget);
+
+        for i in 0..budget {
+            if stop_ids.contains(&next_token) {
+                break;
+            }
+            generated.push(next_token);
+
+            let pos = prompt_tokens.len() + i;
+            let logits =
+                interpreter::forward(next_token, pos, &self.graph, &self.weights, &mut cache);
+            cache.advance();
+            next_token = sampling::sample(&logits, &sampling_config, (pos + 1) as u64);
+        }
+
+        self.tokenizer
+            .decode(&generated)
+            .map_err(|e| to_py(anyhow::anyhow!("failed to decode output: {e}")))
+    }
+
+    /// Architecture name (e.g. ``"Llama"``, ``"Mistral"``).
+    #[getter]
+    fn architecture(&self) -> String {
+        self.config.architecture.to_string()
+    }
+
+    /// Number of transformer layers.
+    #[getter]
+    fn num_layers(&self) -> usize {
+        self.config.num_layers
+    }
+
+    /// Hidden state dimensionality.
+    #[getter]
+    fn hidden_size(&self) -> usize {
+        self.config.hidden_size
+    }
+
+    /// Vocabulary size.
+    #[getter]
+    fn vocab_size(&self) -> usize {
+        self.config.vocab_size
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "forgellm.Model(architecture='{}', layers={}, hidden={}, vocab={})",
+            self.config.architecture,
+            self.config.num_layers,
+            self.config.hidden_size,
+            self.config.vocab_size,
+        )
+    }
+}
+
+// ─── Module registration ──────────────────────────────────────────────────────
+
+/// ForgeLLM Python bindings.
+///
+/// Compile and run small LLMs entirely from Python.
+#[pymodule]
+fn forgellm(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(compile, m)?)?;
+    m.add_class::<Model>()?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds new `crates/forgellm-python` crate using PyO3 0.21 + maturin
- Exposes two top-level Python APIs:
  - `forgellm.compile(model_path, output_dir, target='cpu')` — runs the full AOT pipeline (parse → IR → optimize → codegen) and writes a standalone Rust project
  - `forgellm.Model(model_path)` — interpreter-backed class with `.generate(prompt, max_tokens=64, temperature=0.7)`
- Auto-detects `tokenizer.json` in model directory or parent
- Adds `.github/workflows/publish-python.yml`: matrix wheel builds (Linux manylinux x86-64, macOS x86-64, macOS aarch64) and PyPI OIDC trusted publishing on version tag push

Closes #141

## Test plan

- [ ] `cargo check -p forgellm-python` passes (verified locally)
- [ ] `cargo clippy -p forgellm-python -- -D warnings` passes (verified locally)
- [ ] `cargo fmt --check -p forgellm-python` passes (verified locally)
- [ ] CI matrix builds all three wheel targets without error
- [ ] Smoke-test: `maturin develop && python -c "import forgellm; print(forgellm.__version__)"` prints `0.4.0`