### PR TITLE
docs: update CHANGELOG and HISTORY for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to ForgeLLM are documented here.
 
-## [0.4.0] — 2026-04-10
+## [0.4.0] — 2026-04-11
 
 ### Added
 - **Quantized matmul without dequantization** (`perf`): Q8_0 weights are now kept as raw bytes (int8 + f16 scale blocks). Dot products are computed directly on Q8_0 values — ~2x smaller weight files, better cache utilization (#54)
 - **WASM compilation target** (`feat`): `forge compile --target wasm` generates a `wasm32-unknown-unknown` Rust project with SIMD128 dot product, `#[wasm_bindgen]` exports (`WasmModel::new`, `forward`, `reset_cache`), and a `pkg/model.js` JS glue layer for browser integration (#52)
 - **Speculative decoding** (`feat`): `forge speculative --draft <model> --target-model <model> --output <dir>` compiles both models as library crates and generates a speculative decoding runner — draft runs N tokens ahead, target verifies, accepts matching tokens with KV cache rollback on mismatch (#58)
 - **LoRA adapter support** (`feat`): `forge compile --lora <adapter.safetensors>` merges LoRA weights at compile time (`W += (alpha/rank) * B @ A`) — the AOT binary has adapted weights baked in with zero runtime overhead; supports SafeTensors format (#59)
+- **Mistral and Qwen2 architecture support** (`feat`): `ModelConfig` gains `sliding_window_size` and `qkv_bias` fields; sliding-window attention kernel emitted for Mistral models; QKV bias-add loops emitted for Qwen2 (#143)
+- **E2E correctness validation** (`test`): fast `syn`-based source-validity test runs on every `cargo test`; slow deterministic build+run test gated behind `--ignored` with a nightly CI workflow (#142)
+
+### Performance
+- **Flash Attention kernel** (`perf`): tiled online-softmax attention (`FLASH_ATTN_BLOCK_SIZE=64`) replaces the O(seq_len) scores buffer for models with `max_seq_len > 512` and no sliding window. Caps per-head scratch to 256 bytes regardless of context length (#145)
+- **Parallel matmul threshold 4096 → 512** (`perf`): attention Q/K/V/O projections (N≥512) now run in parallel on all model sizes, not just logits; Qwen2.5-0.5B attention projections (N=896) gain parallelism (#144)
 
 ### Fixed
 - Resolved `clippy::too_many_arguments` lint in `cmd_compile` (refactored to `CompileArgs` struct) that was failing CI under `-D warnings`

--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -13,6 +13,7 @@ System: Darwin arm64 18c (Apple M5 Pro).
 | v0.3.0-dev3 | 2026-04-09 | 119.7 | 119.9 (best 122.1) | 100% |
 | v0.3.0-dev4 | 2026-04-09 | 119.7 | **119.5** (best 122.9) | **100%** |
 | v0.3.1-dev | 2026-04-10 | 119.7 | **117.2** (seed=42, stable) | 98% |
+| v0.4.0 | 2026-04-11 | 119.7 | — (pending) | — |
 
 ## SmolLM2-360M Q8_0 (hidden=960, 32 layers)
 
@@ -29,6 +30,22 @@ System: Darwin arm64 18c (Apple M5 Pro).
 | v0.3.0-dev4 | 2026-04-09 | 33.6 | **34.5** (best 36.2) | **103%** |
 
 ## Analysis
+
+### v0.4.0 — Flash Attention + Broader Architecture Support
+
+Key changes vs v0.3.1-dev:
+
+1. **Parallel matmul threshold 4096 → 512**: attention Q/K/V/O projections on SmolLM2-135M
+   (N=576) now run in parallel. Effect on 135M is modest (Rayon overhead at N=576 is small);
+   larger models (Qwen2.5-0.5B, N=896) gain more.
+2. **Flash Attention** (`max_seq_len > 512`, no SWA): per-head scratch is 64×f32=256 bytes
+   regardless of context length. At 64-token generation benchmarks the tiled loop closely
+   matches the standard path — measurable benefit appears at longer prompts (1K–4K tokens).
+3. **Mistral / Qwen2 support**: sliding-window attention and QKV bias are now emitted
+   correctly; benchmarking Mistral-7B models is now unblocked.
+
+*Fresh benchmark numbers pending — run `./benchmarks/run.sh` on an Apple Silicon machine
+to populate the v0.4.0 row above.*
 
 ### v0.2.0 — AOT Compilation Baseline
 


### PR DESCRIPTION
## Summary

- Adds Flash Attention (#145) and parallel matmul threshold change (#144) to [0.4.0] changelog under a **Performance** heading
- Adds Mistral/Qwen2 architecture support (#143) and E2E correctness tests (#142) to the [0.4.0] **Added** section
- Bumps [0.4.0] date to 2026-04-11
- Adds v0.4.0 row to `benchmarks/HISTORY.md` (pending numbers) with an analysis section explaining the expected impact of Flash Attention and the lowered parallel matmul threshold